### PR TITLE
Fix query semantics and add JSONL output

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Charlie | 42
 | **Inline maths**  | Field expressions | `age + 10 as age_plus_10` |
 | **Table output**  | Aligned terminal tables | `--format table` or `-t` |
 | **YAML output**   | YAML rendering  | `--format yaml` |
-| **CSV / stream**  | `--format csv`, `--stream` | |
+| **CSV / JSONL / stream**  | `--format csv`, `--format jsonl`, `--stream` | |
 | **Follow mode**   | Stream NDJSON line-by-line | `tail -f log \| jonq --follow "..."` |
 | **Worker reuse**  | Reuse jq workers for repeated filters | `--watch`, `--stream`, Python loops |
 | **Path explorer** | Inspect nested JSON paths and types | `jonq data.json` (no query) |
@@ -376,6 +376,11 @@ jonq simple.json "select name, age, city" -t
 jonq simple.json "select name, age" --format csv > output.csv
 ```
 
+### JSONL Output
+```bash
+jonq simple.json "select name, age" --format jsonl > output.jsonl
+```
+
 ### YAML Output
 ```bash
 jonq simple.json "select name, age" --format yaml
@@ -536,9 +541,9 @@ Field(s) 'nme, agge' not found. Available fields: age, city, id, name. Did you m
 
 | Option | Description |
 |--------|-------------|
-| `--format, -f` | Output format: `json` (default), `csv`, `table`, `yaml` |
+| `--format, -f` | Output format: `json` (default), `jsonl`, `csv`, `table`, `yaml` |
 | `-t, --table` | Shorthand for `--format table` |
-| `--stream, -s` | Process root-array JSON in memory-friendly chunks |
+| `--stream, -s` | Process row-wise root-array queries in memory-friendly chunks |
 | `--ndjson` | Force NDJSON mode (auto-detected by default) |
 | `--follow` | Stream NDJSON from stdin line-by-line |
 | `--limit, -n N` | Limit rows post-query |

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,7 +18,7 @@ Execute a query and return parsed Python data by default.
 - **Parameters:**
   - ``source``: Python object, raw JSON string, or file path
   - ``query`` (str or ``CompiledQuery``)
-- **Returns:** Parsed Python data, or raw text when ``format="json"`` or ``format="csv"``
+- **Returns:** Parsed Python data, or raw text when ``format="json"``, ``format="jsonl"``, or ``format="csv"``
 
 **execute(source, query, ...)**
 
@@ -44,7 +44,7 @@ The entry point for the jonq command-line tool.
 
 .. code-block:: bash
 
-   jonq <path/to/json_file> "<query>" [--format csv|json] [--stream] [--watch] [--jq] [--pretty] [--no-color] [--ndjson] [--limit N] [--out PATH] [--version]
+   jonq <path/to/json_file> "<query>" [--format json|jsonl|csv|table|yaml] [--stream] [--watch] [--jq] [--pretty] [--no-color] [--ndjson] [--limit N] [--out PATH] [--version]
 
 Query Parser (jonq.query_parser)
 --------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ Key Features
 - **Aggregations**: ``sum``, ``avg``, ``min``, ``max``, ``count``, ``count(distinct ...)``
 - **GROUP BY** with **HAVING**
 - **Table output**: ``-t`` for aligned terminal tables
-- **YAML output**: ``--format yaml``
+- **JSONL / YAML output**: ``--format jsonl`` and ``--format yaml``
 - **Path explorer**: run ``jonq data.json`` with no query
 - **Interactive REPL**: ``jonq -i data.json`` with tab completion and history
 - **Follow mode**: ``--follow`` to stream NDJSON line-by-line

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -24,11 +24,11 @@ Run ``jonq`` with the following syntax:
    * - Option
      - Description
    * - ``--format, -f``
-     - Output format: ``json`` (default), ``csv``, ``table``, ``yaml``
+     - Output format: ``json`` (default), ``jsonl``, ``csv``, ``table``, ``yaml``
    * - ``-t, --table``
      - Shorthand for ``--format table``
    * - ``--stream, -s``
-     - Process root-array JSON in memory-friendly chunks
+     - Process row-wise root-array queries in memory-friendly chunks
    * - ``--ndjson``
      - Force NDJSON mode (auto-detected by default)
    * - ``--follow``
@@ -516,6 +516,12 @@ Choose how results are displayed:
   .. code-block:: bash
 
       jonq data.json "select name, age" --format csv
+
+- **JSONL:**
+
+  .. code-block:: bash
+
+      jonq data.json "select name, age" --format jsonl
 
 - **YAML:**
 

--- a/docs/source/usage_in_python.rst
+++ b/docs/source/usage_in_python.rst
@@ -60,6 +60,18 @@ Use ``execute(...)`` when you want metadata such as the generated jq filter or r
    print(result.output_format)
    print(result.text)
 
+Use ``format="jsonl"`` when you want newline-delimited JSON for downstream tools:
+
+.. code-block:: python
+
+   result = execute(
+       [{"name": "Alice"}, {"name": "Bob"}],
+       "select name",
+       format="jsonl",
+   )
+
+   print(result.text)
+
 Supported Inputs
 ----------------
 

--- a/jonq/api.py
+++ b/jonq/api.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from os import PathLike
 from typing import Any
 import os
+import re
 
 from jonq.csv_utils import json_to_csv
 from jonq.error_handler import ErrorAnalyzer, QuerySyntaxError, validate_query_against_schema
@@ -107,7 +108,7 @@ def execute(
     limit: int | None = None,
     validate: bool = True,
 ) -> QueryResult:
-    _validate_result_format(format, allowed={"json", "csv"})
+    _validate_result_format(format, allowed={"json", "csv", "jsonl"})
     compiled = _coerce_compiled_query(query)
     source_info = _normalize_source(source)
     _validate_execution_args(source_info, compiled, streaming=streaming, validate=validate)
@@ -139,7 +140,7 @@ async def execute_async(
     limit: int | None = None,
     validate: bool = True,
 ) -> QueryResult:
-    _validate_result_format(format, allowed={"json", "csv"})
+    _validate_result_format(format, allowed={"json", "csv", "jsonl"})
     compiled = _coerce_compiled_query(query)
     source_info = _normalize_source(source)
     _validate_execution_args(source_info, compiled, streaming=streaming, validate=validate)
@@ -173,11 +174,11 @@ def query(
     limit: int | None = None,
     validate: bool = True,
 ) -> Any:
-    _validate_result_format(format, allowed={"python", "json", "csv"})
+    _validate_result_format(format, allowed={"python", "json", "csv", "jsonl"})
     result = execute(
         source,
         query,
-        format="csv" if format == "csv" else "json",
+        format=format if format in {"csv", "jsonl"} else "json",
         streaming=streaming,
         limit=limit,
         validate=validate,
@@ -194,11 +195,11 @@ async def query_async(
     limit: int | None = None,
     validate: bool = True,
 ) -> Any:
-    _validate_result_format(format, allowed={"python", "json", "csv"})
+    _validate_result_format(format, allowed={"python", "json", "csv", "jsonl"})
     result = await execute_async(
         source,
         query,
-        format="csv" if format == "csv" else "json",
+        format=format if format in {"csv", "jsonl"} else "json",
         streaming=streaming,
         limit=limit,
         validate=validate,
@@ -216,7 +217,11 @@ def _normalize_source(source: Any) -> dict[str, str | None]:
     if isinstance(source, PathLike):
         return {"path": os.fspath(source), "json_text": None}
     if isinstance(source, str):
-        if os.path.exists(source) or _looks_like_path(source):
+        if os.path.exists(source):
+            return {"path": source, "json_text": None}
+        if _looks_like_json_text(source):
+            return {"path": None, "json_text": source}
+        if _looks_like_path(source):
             return {"path": source, "json_text": None}
         return {"path": None, "json_text": source}
     if isinstance(source, (bytes, bytearray)):
@@ -233,6 +238,12 @@ def _validate_execution_args(
 ) -> None:
     if streaming and source_info["path"] is None:
         raise ValueError("Streaming mode requires a filesystem path.")
+
+    if streaming and not _supports_chunk_streaming(compiled):
+        raise ValueError(
+            "Streaming mode does not support aggregations, group by, sort, "
+            "distinct, or limit because those require global query state."
+        )
 
     if source_info["path"] is not None:
         if not os.path.exists(source_info["path"]):
@@ -266,14 +277,16 @@ def _build_result(
         raise ValueError(stderr.strip())
 
     text = stdout or ""
+
+    if limit is not None and text and output_format != "csv":
+        text = _apply_limit_to_json_string(text, limit)
+
     if output_format == "csv" and text:
         text = json_to_csv(text)
-
-    if limit is not None and text:
-        if output_format == "csv":
+        if limit is not None:
             text = _apply_limit_to_csv_string(text, limit)
-        else:
-            text = _apply_limit_to_json_string(text, limit)
+    elif output_format == "jsonl" and text:
+        text = _json_to_jsonl(text)
 
     data = None
     if output_format == "json" and text:
@@ -305,6 +318,17 @@ def _apply_limit_to_csv_string(s: str, n: int) -> str:
     return "\n".join(lines[:1] + lines[1 : 1 + max(0, n)])
 
 
+def _json_to_jsonl(s: str) -> str:
+    try:
+        data = loads(s)
+    except (TypeError, ValueError):
+        return s
+
+    if isinstance(data, list):
+        return "\n".join(dumps(item) for item in data)
+    return dumps(data)
+
+
 def transform_nested_array_path(field_path):
     path = parse_path(field_path)
     return generate_jq_path(path)
@@ -332,6 +356,30 @@ def _looks_like_path(source: str) -> bool:
     return source == "-" or source.startswith((".", "~")) or os.sep in source or source.endswith(
         (".json", ".jsonl", ".ndjson")
     )
+
+
+def _looks_like_json_text(source: str) -> bool:
+    stripped = source.lstrip()
+    if not stripped:
+        return False
+    if stripped[0] in "[{":
+        return True
+    if stripped[0] == '"' and len(stripped) >= 2:
+        return True
+    if stripped.startswith(("true", "false", "null")):
+        return True
+    return bool(
+        re.match(r"^[+-]?((\d+(\.\d*)?)|(\.\d+))([eE][+-]?\d+)?\s*$", stripped)
+    )
+
+
+def _supports_chunk_streaming(compiled: CompiledQuery) -> bool:
+    if compiled.group_by or compiled.order_by or compiled.limit or compiled.distinct:
+        return False
+    for field in compiled.fields:
+        if field[0] in {"aggregation", "count_distinct"}:
+            return False
+    return True
 
 
 def _validate_result_format(format: str, *, allowed: set[str]) -> None:

--- a/jonq/executor.py
+++ b/jonq/executor.py
@@ -12,6 +12,11 @@ import aiofiles
 logger = logging.getLogger(__name__)
 
 
+def _filter_emits_multiple_values(jq_filter: str) -> bool:
+    stripped = jq_filter.lstrip()
+    return stripped.startswith(".[]") or stripped.startswith(".[]?")
+
+
 def _run_jq_raw(jq_filter, json_text):
     try:
         worker = get_worker(jq_filter)
@@ -43,7 +48,7 @@ def run_jq(arg1, arg2):
 
 
 def run_jq_streaming(json_file, jq_filter, chunk_size=1000):
-    emits_objects = jq_filter.startswith(".[]") or "| .[" in jq_filter
+    emits_objects = _filter_emits_multiple_values(jq_filter)
     wrapper = f"[{jq_filter}]" if emits_objects else jq_filter
 
     def _process_chunk(chunk_json):
@@ -103,7 +108,7 @@ async def run_jq_async(arg1, arg2):
 
 
 async def run_jq_streaming_async(json_file, jq_filter, chunk_size=1000):
-    emits_objects = jq_filter.startswith(".[]") or "| .[" in jq_filter
+    emits_objects = _filter_emits_multiple_values(jq_filter)
     wrapper = f"[{jq_filter}]" if emits_objects else jq_filter
 
     async def _process_chunk_async(chunk_json):

--- a/jonq/generator.py
+++ b/jonq/generator.py
@@ -362,6 +362,53 @@ def make_selector_from_path(path_with_arrays: str) -> str:
     return " | ".join(pieces)
 
 
+def _split_array_context(path: str) -> tuple[Optional[str], str]:
+    marker = "[]"
+    idx = path.rfind(marker)
+    if idx == -1:
+        return None, path
+    context_path = path[: idx + len(marker)]
+    local_path = path[idx + len(marker) :].lstrip(".")
+    return context_path, local_path
+
+
+def _implicit_field_array_context(fields) -> Optional[str]:
+    contexts = set()
+    has_array_field = False
+    for tup in fields:
+        ftype = tup[0]
+        if ftype == "field":
+            path = tup[1]
+        elif ftype == "function":
+            path = tup[2]
+        else:
+            continue
+        if "[]" not in path:
+            continue
+        context_path, _ = _split_array_context(path)
+        if context_path:
+            has_array_field = True
+            contexts.add(context_path)
+    if has_array_field and len(contexts) == 1:
+        return next(iter(contexts))
+    return None
+
+
+def _strip_array_context(path: str, context_path: str) -> str:
+    if path.startswith(context_path):
+        return path[len(context_path) :].lstrip(".")
+    return path
+
+
+def _sort_filter(order_by: str, sort_direction: str) -> str:
+    sort_expr = generate_jq_path(
+        parse_path(order_by), context="root", null_check=False
+    )
+    return f" | sort_by({sort_expr})" + (
+        " | reverse" if sort_direction == "desc" else ""
+    )
+
+
 def _gen_field_selector(ftype: str, data: list, base_context: str) -> Optional[str]:
     if ftype == "field":
         field, alias = data
@@ -492,6 +539,32 @@ def generate_jq_filter(
                     updated_fields.append(tup)
             fields = updated_fields
 
+    if not from_path and not group_by and not condition:
+        field_array_context = _implicit_field_array_context(fields)
+        if field_array_context:
+            base_selector = make_selector_from_path(field_array_context)
+            base_context = "array"
+            updated_fields = []
+            for tup in fields:
+                if tup[0] == "field":
+                    _, path, alias = tup
+                    updated_fields.append(
+                        ("field", _strip_array_context(path, field_array_context), alias)
+                    )
+                elif tup[0] == "function":
+                    _, func, param, alias = tup
+                    updated_fields.append(
+                        (
+                            "function",
+                            func,
+                            _strip_array_context(param, field_array_context),
+                            alias,
+                        )
+                    )
+                else:
+                    updated_fields.append(tup)
+            fields = updated_fields
+
     all_aggregations = all(ft in ("aggregation", "count_distinct") for ft, *_ in fields)
     if all_aggregations and not group_by:
         base_data = base_selector or '(if type=="array" then .[] else . end)'
@@ -516,11 +589,12 @@ def generate_jq_filter(
                 )
                 continue
             _, func, param, alias = tup
-            raw = f"{base_data} | .{param.lstrip('.')}"
-            wrapped = wrap(raw)
             if func == "count" and param == "*":
-                selection.append(f'"{alias}": length')
+                selection.append(f'"{alias}": ([ {base_data} ] | length)')
                 continue
+            path_jq = generate_jq_path(parse_path(param), base_context)
+            raw = f"{base_data} | {path_jq}"
+            wrapped = wrap(raw)
             if func == "sum":
                 selection.append(
                     f'"{alias}": ({wrapped} | map(select(type=="number")) | add // 0)'
@@ -589,9 +663,7 @@ def generate_jq_filter(
         if having:
             jq_filter += f" | map(select({process_having_condition(having, fields)}))"
         if order_by:
-            jq_filter += f" | sort_by(.{order_by})" + (
-                " | reverse" if sort_direction == "desc" else ""
-            )
+            jq_filter += _sort_filter(order_by, sort_direction)
         if limit:
             jq_filter += f" | .[0:{limit}]"
     else:
@@ -608,9 +680,7 @@ def generate_jq_filter(
             if distinct:
                 jq_filter += " | unique"
             if order_by:
-                jq_filter += f" | sort_by(.{order_by})" + (
-                    " | reverse" if sort_direction == "desc" else ""
-                )
+                jq_filter += _sort_filter(order_by, sort_direction)
             if limit:
                 jq_filter += f" | .[0:{limit}]"
 
@@ -641,7 +711,7 @@ def generate_jq_filter(
                 if s:
                     sel.append(s)
             map_filter = f"{{ {', '.join(sel)} }}"
-            if from_path:
+            if from_path or base_selector:
                 body = (
                     f"{base_selector} | "
                     + ("select({}) | ".format(condition) if condition else "")
@@ -668,9 +738,7 @@ def generate_jq_filter(
             if distinct:
                 jq_filter += " | unique"
             if order_by:
-                jq_filter += f" | sort_by(.{order_by})" + (
-                    " | reverse" if sort_direction == "desc" else ""
-                )
+                jq_filter += _sort_filter(order_by, sort_direction)
             if limit:
                 jq_filter += f" | .[0:{limit}]"
     logging.info(f"Generated jq filter: {jq_filter}")

--- a/jonq/main.py
+++ b/jonq/main.py
@@ -153,14 +153,17 @@ def _sample_json_for_schema(json_file: str):
                 stderr=subprocess.PIPE,
             )
             samples = []
+            reached_sample_limit = False
             for i, line in enumerate(proc.stdout):
                 if i >= SCHEMA_PATH_SAMPLE_ROWS:
+                    reached_sample_limit = True
                     break
                 line = line.strip()
                 if line:
                     samples.append(json.loads(line))
+            if reached_sample_limit and proc.poll() is None:
+                proc.terminate()
             stderr = proc.stderr.read().strip()
-            proc.terminate()
             proc.wait(timeout=1)
             if proc.returncode not in (0, -15):
                 raise RuntimeError(stderr or "jq failed while sampling array")
@@ -501,6 +504,20 @@ def _json_to_yaml(json_text: str) -> str:
         return json_text
 
 
+def _json_to_jsonl(json_text: str) -> str:
+    try:
+        data = json.loads(json_text)
+    except (json.JSONDecodeError, TypeError):
+        return json_text
+
+    if isinstance(data, list):
+        return "\n".join(
+            json.dumps(item, ensure_ascii=False, separators=(",", ":"))
+            for item in data
+        )
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+
+
 def _json_to_yaml_simple(json_text: str) -> str:
     try:
         data = json.loads(json_text)
@@ -605,7 +622,7 @@ compdef _jonq jonq'''
         return '''# jonq fish completion
 # Add to ~/.config/fish/completions/jonq.fish
 complete -c jonq -s i -l interactive -d 'Interactive mode' -r -F
-complete -c jonq -s f -l format -d 'Output format' -x -a 'json csv table yaml'
+complete -c jonq -s f -l format -d 'Output format' -x -a 'json jsonl csv table yaml'
 complete -c jonq -s t -l table -d 'Table output'
 complete -c jonq -s s -l stream -d 'Streaming mode'
 complete -c jonq -s n -l limit -d 'Limit rows' -x
@@ -659,6 +676,8 @@ async def _follow_stdin(query: str, options: dict) -> None:
                         result = json_to_table(result, color=is_tty and not options.get("no_color"))
                     elif options["format"] == "yaml":
                         result = _json_to_yaml(result)
+                    elif options["format"] == "jsonl":
+                        result = _json_to_jsonl(result)
                     elif is_tty and not options.get("no_color"):
                         result = _pretty_json_string(result)
                         result = _colorize_json(result)
@@ -918,9 +937,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-f",
         "--format",
-        choices=("json", "csv", "table", "yaml"),
+        choices=("json", "jsonl", "csv", "table", "yaml"),
         default="json",
-        help="Output format (json, csv, table, yaml)",
+        help="Output format (json, jsonl, csv, table, yaml)",
     )
     parser.add_argument(
         "-t",
@@ -933,7 +952,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--stream",
         dest="streaming",
         action="store_true",
-        help="Process large files in streaming mode",
+        help="Process row-wise root-array queries in streaming mode",
     )
     parser.add_argument(
         "--ndjson",

--- a/jonq/parser.py
+++ b/jonq/parser.py
@@ -141,39 +141,84 @@ def _find_keyword(s: str, keyword: str) -> int:
     return -1
 
 
-def parse_expression(expr_str: str) -> Expression:
+def _strip_outer_expr_parens(expr_str: str) -> str:
     expr_str = expr_str.strip()
+    while expr_str.startswith("(") and expr_str.endswith(")"):
+        depth = 0
+        in_sq = in_dq = False
+        wraps = True
+        for i, ch in enumerate(expr_str):
+            if ch == "'" and not in_dq:
+                in_sq = not in_sq
+            elif ch == '"' and not in_sq:
+                in_dq = not in_dq
+            elif ch == "(" and not in_sq and not in_dq:
+                depth += 1
+            elif ch == ")" and not in_sq and not in_dq:
+                depth -= 1
+                if depth == 0 and i != len(expr_str) - 1:
+                    wraps = False
+                    break
+        if not wraps:
+            break
+        expr_str = expr_str[1:-1].strip()
+    return expr_str
+
+
+def _find_top_level_operator(expr_str: str, operators: list[str]):
+    depth = 0
+    in_sq = in_dq = False
+    i = len(expr_str) - 1
+    while i >= 0:
+        ch = expr_str[i]
+        if ch == "'" and not in_dq:
+            in_sq = not in_sq
+        elif ch == '"' and not in_sq:
+            in_dq = not in_dq
+        elif ch == ")" and not in_sq and not in_dq:
+            depth += 1
+        elif ch == "(" and not in_sq and not in_dq:
+            depth -= 1
+        elif depth == 0 and not in_sq and not in_dq:
+            for op in operators:
+                if op == "||":
+                    for pat in (" || ", "||"):
+                        start = i - len(pat) + 1
+                        if start >= 0 and expr_str[start : i + 1] == pat:
+                            return start, op
+                else:
+                    pat = f" {op} "
+                    start = i - len(pat) + 1
+                    if start >= 0 and expr_str[start : i + 1] == pat:
+                        return start, op
+        i -= 1
+    return None, None
+
+
+def parse_expression(expr_str: str) -> Expression:
+    expr_str = _strip_outer_expr_parens(expr_str)
 
     if expr_str.lower().startswith("case "):
         return _parse_case_expression(expr_str)
 
-    depth = 0
-    for i, ch in enumerate(expr_str):
-        if ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-        elif depth == 0:
-            for op in ["||", "+", "-", "*", "/"]:
-                pat = f" {op} " if op != "||" else "||"
-                if op == "||":
-                    for p in [" || ", "||"]:
-                        if expr_str.startswith(p, i):
-                            left = expr_str[:i].rstrip()
-                            right = expr_str[i + len(p) :].lstrip()
-                            return Expression(
-                                ExprType.OPERATION,
-                                "+",  # jq uses + for string concat
-                                [parse_expression(left), parse_expression(right)],
-                            )
-                elif expr_str.startswith(pat, i):
-                    left = expr_str[:i].rstrip()
-                    right = expr_str[i + len(pat) :].lstrip()
-                    return Expression(
-                        ExprType.OPERATION,
-                        op,
-                        [parse_expression(left), parse_expression(right)],
-                    )
+    for operators in (["||", "+", "-"], ["*", "/", "%"]):
+        op_index, op = _find_top_level_operator(expr_str, operators)
+        if op_index is not None:
+            pat_len = len(op)
+            if op == "||":
+                if expr_str.startswith(" || ", op_index):
+                    pat_len = 4
+                elif expr_str.startswith("||", op_index):
+                    pat_len = 2
+            else:
+                pat_len = len(f" {op} ")
+            left = expr_str[:op_index].rstrip()
+            right = expr_str[op_index + pat_len :].lstrip()
+            return Expression(
+                ExprType.OPERATION,
+                "+" if op == "||" else op,
+                [parse_expression(left), parse_expression(right)],
+            )
 
     agg_match = re.match(r"(\w+)\s*\(", expr_str)
     if agg_match:

--- a/jonq/query_parser.py
+++ b/jonq/query_parser.py
@@ -243,6 +243,7 @@ _SCALAR_FUNCTIONS = {
     "ltrim", "rtrim", "tojson", "fromjson",
 }
 _MULTI_ARG_FUNCTIONS = {"coalesce", "if_null"}
+_AGGREGATE_FUNCTIONS = {"count", "sum", "avg", "min", "max"}
 _ARITHMETIC_OPS = {"+", "-", "*", "/", "%", "^", "||"}
 
 
@@ -391,12 +392,14 @@ def parse_query(tokens: list[str]) -> tuple:
                 else:
                     is_plain_path = re.fullmatch(r"[\w\.\[\]]+", inner_expr)
                     is_star = inner_expr.strip() == "*"
+                    if func_lower not in _AGGREGATE_FUNCTIONS:
+                        raise ValueError(f"Unknown function '{func}'")
                     if is_plain_path or is_star:
                         alias = (
                             alias
                             or f"{func}_{inner_expr.replace('.', '_').replace('[', '_').replace(']', '').replace('*', 'star')}"
                         )
-                        fields.append(("aggregation", func, inner_expr, alias))
+                        fields.append(("aggregation", func_lower, inner_expr, alias))
                     else:
                         alias = alias or f"expr_{len(fields) + 1}"
                         fields.append(("expression", f"{func} ( {inner_expr} )", alias))
@@ -411,9 +414,8 @@ def parse_query(tokens: list[str]) -> tuple:
                         depth += 1
                     elif token == ")":
                         depth -= 1
-                    elif (
-                        depth == 0
-                        and token in [",", "as"]
+                    elif depth == 0 and (
+                        token in [",", "as"]
                         or token.lower()
                         in ["if", "sort", "group", "having", "from", "limit"]
                     ):
@@ -460,6 +462,10 @@ def parse_query(tokens: list[str]) -> tuple:
             expecting_field = False
         else:
             break
+    if not fields:
+        raise ValueError("Expected field list after 'select'")
+    if expecting_field:
+        raise ValueError("Expected field name after comma")
     from_path = None
     if i < len(tokens) and tokens[i].lower() == "from":
         i += 1
@@ -468,6 +474,7 @@ def parse_query(tokens: list[str]) -> tuple:
             "sort",
             "group",
             "having",
+            "limit",
         ]:
             from_path = tokens[i]
             i += 1
@@ -533,7 +540,7 @@ def parse_query(tokens: list[str]) -> tuple:
         having = " ".join(having_tokens)
     if i < len(tokens) and tokens[i].lower() == "from":
         i += 1
-        if i < len(tokens) and tokens[i].lower() not in ["sort"]:
+        if i < len(tokens) and tokens[i].lower() not in ["sort", "limit"]:
             from_path = tokens[i]
             i += 1
         else:
@@ -574,6 +581,8 @@ def parse_query(tokens: list[str]) -> tuple:
             i += 1
         else:
             raise ValueError("Expected number after 'limit'")
+    if i < len(tokens):
+        raise ValueError(f"Unexpected token {tokens[i]!r} at position {i}")
     return (
         fields,
         condition,

--- a/jonq/tokenizer.py
+++ b/jonq/tokenizer.py
@@ -32,7 +32,7 @@ def tokenize_with_lexer(query):
         ),
         ("FUNCTION_CALL", r"\w+\s*\(\s*\*\s*\)"),
         ("FUNCTION_PARAM", r"\w+\s*\(\s*[\w\.\[\]]+\s*\)"),
-        ("OPERATOR", r"\|\||<=|>=|!=|=|<|>|\+|\*|\/"),
+        ("OPERATOR", r"\|\||<=|>=|!=|=|<|>|\+|\*|\/|%"),
         ("ARITHMETIC_MINUS", r"\s-\s"),
         ("STRING", r'"(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\''),
         ("NUMBER", r"\d+(?:\.\d+)?"),

--- a/tests/jq_filter_test.py
+++ b/tests/jq_filter_test.py
@@ -174,9 +174,10 @@ def test_arithmetic_addition():
 
 
 def test_count_star():
-    assert '{ "total_count": length }' == generate_jq_filter(
+    r = generate_jq_filter(
         [("aggregation", "count", "*", "total_count")], None, None, None, None, None
     )
+    _has(r, ['"total_count"', "if type==", "length"])
 
 
 def test_count_star_with_condition():

--- a/tests/test_semantic_regressions.py
+++ b/tests/test_semantic_regressions.py
@@ -1,0 +1,92 @@
+import json
+import os
+import tempfile
+
+import pytest
+
+from jonq.api import compile_query, execute, query
+
+
+def test_count_star_respects_filter():
+    data = [{"age": 10}, {"age": 30}, {"age": 40}]
+
+    result = query(data, "select count(*) as over_25 if age > 25")
+
+    assert result == {"over_25": 2}
+
+
+def test_count_star_respects_from_path():
+    data = {"products": [{"name": "A"}, {"name": "B"}]}
+
+    result = query(data, "select count(*) as n from products")
+
+    assert result == {"n": 2}
+
+
+def test_select_requires_field_list():
+    with pytest.raises(ValueError, match="Expected field"):
+        compile_query("select")
+
+
+def test_select_rejects_trailing_tokens():
+    with pytest.raises(ValueError, match="Unexpected token"):
+        compile_query("select name limit 1 junk")
+
+
+def test_from_requires_path_before_limit():
+    with pytest.raises(ValueError, match="Expected path after 'from'"):
+        compile_query("select name from limit 1")
+
+
+def test_arithmetic_precedence_matches_standard_math():
+    result = query([{"age": 10}], "select age * 2 + 3 as total")
+
+    assert result == [{"total": 23}]
+
+
+def test_inline_shared_array_fields_stay_aligned():
+    data = {"products": [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]}
+
+    result = query(data, "select products[].id, products[].name")
+
+    assert result == [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
+
+
+def test_json_string_with_slash_is_not_treated_as_path():
+    payload = json.dumps([{"url": "https://example.com", "name": "A"}])
+
+    result = query(payload, "select name")
+
+    assert result == [{"name": "A"}]
+
+
+def test_api_streaming_rejects_global_queries():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump([{"id": i} for i in range(1005)], f)
+        path = f.name
+
+    try:
+        with pytest.raises(ValueError, match="Streaming mode does not support"):
+            query(path, "select count(*) as n", streaming=True, validate=False)
+    finally:
+        os.unlink(path)
+
+
+def test_api_streaming_keeps_simple_select_shape():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump([{"id": i} for i in range(3)], f)
+        path = f.name
+
+    try:
+        result = query(path, "select id", streaming=True, validate=False)
+        assert result == [{"id": 0}, {"id": 1}, {"id": 2}]
+    finally:
+        os.unlink(path)
+
+
+def test_jsonl_output_format():
+    result = execute([{"name": "A"}, {"name": "B"}], "select name", format="jsonl")
+
+    assert result.output_format == "jsonl"
+    assert result.text == '{"name":"A"}\n{"name":"B"}'
+    assert result.data is None


### PR DESCRIPTION
## Summary
- Fix non-group `count(*)` so it respects `if` filters and `from` paths.
- Tighten parser validation for empty field lists, trailing tokens, unknown functions, and invalid `from` clauses.
- Fix arithmetic precedence and shared inline array field alignment.
- Add `jsonl` output support across the Python API, CLI, completions, and docs.
- Guard streaming mode against global queries that require full-input state instead of returning partial chunk results.
- Prevent no-query schema sampling from blocking after the sample limit is reached.

## Testing
- [x] `pytest -q` (`337 passed`)
- [x] `python -m py_compile jonq/*.py`

## Git Hygiene
- Committed only the query semantics, JSONL, docs, and regression test changes.
- Left pre-existing local edits unstaged: `.DS_Store`, `.gitignore`, `docs/.DS_Store`, `jonq/table_utils.py`, `tests/test_parser_edge_cases.py`, `MONETIZATION_ROADMAP.md`, and `OSS_WEDGE_PLAN.md`.