### PR TITLE
Clarify CLI comparison positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Alice   | 35
 Charlie | 42
 ```
 
-> **jonq is not a database.** It is a readable jq frontend for exploring, extracting, and reshaping JSON. If you need joins, window functions, or large-scale analytics, shape the JSON with jonq first and then hand it to DuckDB, Polars, or Pandas.
+> **jonq is not a database.** It is a readable jq frontend for exploring, extracting, and reshaping JSON in terminal workflows.
 
 ---
 
@@ -43,11 +43,13 @@ Charlie | 42
 - Stream and filter NDJSON log output in real time
 
 ### Use something else when you need
-- **Tabular analytics** — DuckDB, Polars, Pandas
-- **Joins across files** — a database or dataframe engine
+- **Exact jq control** — raw `jq`
+- **Python expressions over JSON** — [`jello`](https://github.com/kellyjonbrazil/jello)
+- **Flattened assignment-style JSON output** — [`gron`](https://github.com/tomnomnom/gron)
+- **Joins across files** — a database or analytics engine
 - **Large-scale ETL** — tools built for analytical pipelines
 
-**Rule of thumb:** if the problem is still "I need to understand this JSON", jonq is a good fit. If the problem has become relational analytics, move to a database.
+**Rule of thumb:** if the problem is still "I need to understand or reshape this JSON from the shell", jonq is a good fit. If the problem has become relational analytics or production data movement, use a tool built for that job.
 
 ## Features at a glance
 
@@ -127,9 +129,10 @@ Charlie | 42
 
 - Use **jonq** when the source of truth is still raw JSON and you need to inspect fields, paths, filters, or nested values quickly.
 - Use **raw jq** when you already know the exact jq filter you want and do not need the friendlier syntax.
-- Use **DuckDB / Polars / Pandas** after the JSON has become a tabular analytics problem.
+- Use **jello** when you want to process JSON with Python expressions from the CLI.
+- Use **gron** when you want to flatten JSON into grep-friendly assignment lines.
 
-**TL;DR:** jonq is the "understand and shape this JSON" step, not the database step.
+**TL;DR:** jonq is the "understand and shape this JSON from the terminal" step, not a database or ETL layer.
 
 ---
 
@@ -598,7 +601,7 @@ When outputting to a terminal, jonq auto-pretty-prints and colorizes JSON. Pipe 
 * Advanced jq Features: Some advanced jq features (recursive descent, custom filters) aren't exposed in the jonq syntax.
 * Custom Functions: User-defined functions aren't supported.
 * Joins: Cross-file joins are not supported — use a database for relational queries.
-* Window Functions: Not supported — use DuckDB or Polars for analytical queries.
+* Window Functions: Not supported — use an analytical query engine for analytical queries.
 
 ## Docs
 

--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -4,12 +4,12 @@ Comparison
 Where jonq Fits
 ----------------
 
-jonq is a JSON exploration and extraction tool. It is not a database, dataframe engine, or BI layer.
+jonq is a CLI JSON exploration and extraction tool. It is not a database, ETL system, or BI layer.
 
 .. important::
 
-   Use jonq while the problem is still "understand this JSON" or "reshape this payload".
-   Once the problem becomes relational analytics, joins, window functions, or large-scale aggregation, move to an analytical tool.
+   Use jonq while the problem is still "understand this JSON" or "reshape this payload" from the shell.
+   Once the problem becomes relational analytics, joins, window functions, or large-scale data movement, move to a tool built for that job.
 
 When to Use jonq
 ~~~~~~~~~~~~~~~~~
@@ -23,15 +23,16 @@ When to Use Something Else
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Use **raw jq** when you already know the exact jq filter you want.
-- Use **DuckDB / Polars / Pandas** when the data is now a tabular analytics problem.
-- Use a **database or warehouse** when you need joins, window functions, or repeated analytical queries over larger datasets.
+- Use `jello <https://github.com/kellyjonbrazil/jello>`_ when you want Python expressions over JSON from the CLI.
+- Use `gron <https://github.com/tomnomnom/gron>`_ when you want grep-friendly flattened assignment lines.
+- Use an **analytics engine or database** when you need joins, window functions, or repeated analytical queries over larger datasets.
 
 Typical Workflow
 ~~~~~~~~~~~~~~~~~
 
 1. Explore unknown JSON with jonq.
 2. Extract or normalize the fields you need.
-3. Pipe the result into DuckDB, Polars, Pandas, or a database if you need analytics afterward.
+3. Pipe the result into the next shell command, script, or analytical system if you need more processing afterward.
 
 jonq vs raw jq
 ---------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -699,4 +699,4 @@ Known Limitations
 - **Advanced jq Features**: Some complex ``jq`` functionalities (e.g., recursive descent or custom filters) are not exposed through ``jonq``'s readable query syntax.
 - **Joins**: ``jonq`` does not support joining data across multiple JSON files.
 - **Custom Functions**: Users cannot define custom functions within queries.
-- **Window Functions**: Not supported — use DuckDB or Polars for analytical queries.
+- **Window Functions**: Not supported — use an analytical query engine for analytical queries.


### PR DESCRIPTION
## Summary
- Resolves #2.
- Removes named DuckDB, Polars, and Pandas comparisons from README and Sphinx docs.
- Reframes jonq as a terminal JSON exploration/extraction tool rather than comparing it to database/dataframe tools.
- Adds closer CLI alternatives: `jq`, `jello`, and `gron`.
- Keeps unsupported joins/window functions guidance generic instead of naming unrelated tools.

## Testing
- [x] `pytest -q` (`337 passed`)
- [x] `rg -n "DuckDB|Polars|Pandas|dataframe" README.md docs/source USAGE.md SYNTAX.md CHANGELOG.md` returned no matches
- [x] `LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-issue2` succeeded with one expected intersphinx network warning in the sandbox

## Git Hygiene
- Separate docs-only branch from `origin/main` after PR #3 was merged.
- Committed only `README.md`, `docs/source/comparison.rst`, and `docs/source/usage.rst`.
- Left pre-existing local edits unstaged: `.DS_Store`, `.gitignore`, `docs/.DS_Store`, `jonq/table_utils.py`, `tests/test_parser_edge_cases.py`, `MONETIZATION_ROADMAP.md`, and `OSS_WEDGE_PLAN.md`.