### PR TITLE
Refresh README and user documentation

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -7,6 +7,8 @@ Thanks for your interest in helping with jonq! Here's how you can contribute:
 1. Fork the repo
 2. Clone your fork: `git clone https://github.com/duriantaco/jonq.git`
 3. Install for development: `pip install -e .`
+4. Install test dependencies: `pip install pytest pytest-asyncio`
+5. Install docs dependencies when editing docs: `pip install -r docs/requirements.txt`
 
 ## How to Contribute
 
@@ -16,12 +18,13 @@ Thanks for your interest in helping with jonq! Here's how you can contribute:
 - Mention your environment (Python version, OS)
 
 ### Submitting Changes
-1. Create a branch: `git checkout -b fix-something`
+1. Create a branch: `git switch -c fix-something`
 2. Make your changes
 3. Run tests: `pytest`
-4. Commit with a clear message
-5. Push to your fork
-6. Open a pull request
+4. Build docs when documentation changed: `python -m sphinx -b html docs/source /tmp/jonq-docs`
+5. Commit with a clear message
+6. Push to your fork
+7. Open a pull request
 
 ### Code Style
 - Follow PEP 8 basics
@@ -29,6 +32,11 @@ Thanks for your interest in helping with jonq! Here's how you can contribute:
 
 ## Testing
 Run `pytest` before submitting your changes.
+
+## Documentation
+Keep `README.md`, `USAGE.md`, `SYNTAX.md`, and the Sphinx docs in `docs/source/`
+in sync when changing CLI behavior, query syntax, output formats, or the Python
+API.
 
 ## Need Help?
 Open an issue with your question!

--- a/README.md
+++ b/README.md
@@ -1,570 +1,380 @@
 <div align="center">
-  <img src="docs/source/_static/jonq.png" alt="jonq — SQL-like JSON query tool for the command line" width="200"/>
+  <img src="docs/source/_static/jonq.png" alt="jonq - SQL-like JSON query tool for the command line" width="200"/>
 
-# jonq — query JSON with SQL-like syntax from the terminal
+# jonq - readable JSON queries for the terminal
 
-### A readable alternative to jq for JSON extraction, filtering, and exploration
+### A jq-powered CLI for inspecting, filtering, and reshaping JSON without writing raw jq
 
 [![PyPI version](https://img.shields.io/pypi/v/jonq.svg)](https://pypi.org/project/jonq/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/jonq.svg)](https://pypi.org/project/jonq/)
 [![CI tests](https://github.com/duriantaco/jonq/actions/workflows/tests.yml/badge.svg)](https://github.com/duriantaco/jonq/actions)
 [![Documentation Status](https://readthedocs.org/projects/jonq/badge/?version=latest)](https://jonq.readthedocs.io)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](License)
 [![Skylos Grade](https://img.shields.io/badge/Skylos-A%2B%20%28100%29-brightgreen)](https://github.com/duriantaco/skylos)
 </div>
 
 ---
 
-## What is jonq?
+## What jonq is
 
-**jonq** is a command-line JSON query tool that lets you `select`, `filter`, `group`, and `reshape` JSON data using SQL-like syntax instead of raw jq. It generates pure jq under the hood, so you get jq's speed with a syntax you can actually remember.
+`jonq` is a command-line JSON query tool. It lets you write readable, SQL-like queries such as:
 
 ```bash
-# Instead of: jq '.[] | select(.age > 30) | {name, age}'
-jonq data.json "select name, age if age > 30" -t
+jonq users.json "select name, age if age > 30" -t
 ```
 
+Instead of raw jq:
+
+```bash
+jq '.[] | select(.age > 30) | {name, age}' users.json
 ```
-name    | age
---------|----
-Alice   | 35
-Charlie | 42
-```
 
-> **jonq is not a database.** It is a readable jq frontend for exploring, extracting, and reshaping JSON in terminal workflows.
+jonq compiles your query to jq and executes it with a reusable jq worker. It is useful when you need to understand an unfamiliar JSON payload, extract fields, filter rows, flatten nested arrays, or turn JSON into table, CSV, JSONL, or YAML output.
 
----
+> jonq is not a database, ETL framework, or analytics engine. It is a JSON exploration and shaping tool for terminal workflows.
 
-### Use jonq when you need to
-- Query JSON from APIs, config files, or log streams in the terminal
-- Explore unfamiliar JSON with the built-in path explorer
-- Write readable jq one-liners in shell scripts and CI pipelines
-- Filter, aggregate, or reshape nested JSON without memorizing jq syntax
-- Stream and filter NDJSON log output in real time
+## When to use it
 
-### Use something else when you need
-- **Exact jq control** — raw `jq`
-- **Python expressions over JSON** — [`jello`](https://github.com/kellyjonbrazil/jello)
-- **Flattened assignment-style JSON output** — [`gron`](https://github.com/tomnomnom/gron)
-- **Joins across files** — a database or analytics engine
-- **Large-scale ETL** — tools built for analytical pipelines
+Use jonq when you need to:
 
-**Rule of thumb:** if the problem is still "I need to understand or reshape this JSON from the shell", jonq is a good fit. If the problem has become relational analytics or production data movement, use a tool built for that job.
+- inspect an API response, config file, generated JSON, or log payload
+- select and rename fields without remembering jq object syntax
+- filter JSON with readable conditions
+- query nested objects and arrays
+- produce table, CSV, JSONL, YAML, or compact JSON output
+- run the same query in shell scripts, CI, or Python code
+- follow NDJSON logs line-by-line
 
-## Features at a glance
+Use another tool when you need:
 
-| Category          | What you can do | Example |
-|-------------------|-----------------|---------|
-| **Selection**     | Pick fields     | `select name, age` |
-| **Wildcard**      | All fields      | `select *` |
-| **DISTINCT**      | Unique results  | `select distinct city` |
-| **Filtering**     | `and / or / not / between / contains / in / like` | `if age > 30 and city = 'NY'` |
-| **IS NULL**       | Null checks     | `if email is not null` |
-| **Aggregations**  | `sum avg min max count` | `select avg(price) as avg_price` |
-| **COUNT DISTINCT**| Unique counts   | `select count(distinct city) as n` |
-| **Grouping**      | `group by` + `having`   | `... group by city having count > 2` |
-| **Ordering**      | `sort <field> [asc\|desc]` | `sort age desc` |
-| **LIMIT**         | Standalone limit | `select * limit 10` |
-| **CASE/WHEN**     | Conditional expressions | `case when age > 30 then 'senior' else 'junior' end` |
-| **COALESCE**      | Null fallback   | `coalesce(nickname, name) as display` |
-| **String concat** | `+` or `\|\|`   | `first \|\| ' ' \|\| last as full_name` |
-| **Nested arrays** | `from [].orders` or inline paths | `select products[].name ...` |
-| **String funcs**  | `upper lower length trim` | `select upper(name) as name_upper` |
-| **Math funcs**    | `round abs ceil floor` | `select round(price) as price_r` |
-| **Type casting**  | `int float str type` | `select int(price) as price` |
-| **Date/time**     | `todate fromdate date` | `select todate(ts) as date` |
-| **Inline maths**  | Field expressions | `age + 10 as age_plus_10` |
-| **Table output**  | Aligned terminal tables | `--format table` or `-t` |
-| **YAML output**   | YAML rendering  | `--format yaml` |
-| **CSV / JSONL / stream**  | `--format csv`, `--format jsonl`, `--stream` | |
-| **Follow mode**   | Stream NDJSON line-by-line | `tail -f log \| jonq --follow "..."` |
-| **Worker reuse**  | Reuse jq workers for repeated filters | `--watch`, `--stream`, Python loops |
-| **Path explorer** | Inspect nested JSON paths and types | `jonq data.json` (no query) |
-| **Interactive REPL** | Tab completion + history | `jonq -i data.json` |
-| **Watch mode**    | Re-run on file change | `jonq data.json "select *" --watch` |
-| **URL fetch**     | Query remote JSON | `jonq https://api.example.com/data "select id"` |
-| **Multi-file glob** | Query across files | `jonq 'logs/*.json' "select *"` |
-| **Auto stdin**    | Auto-detect piped input | `curl ... \| jonq "select id"` |
-| **Auto NDJSON**   | Auto-detect line-delimited JSON | No flag needed |
-| **Shell completions** | Bash/Zsh/Fish completions | `jonq --completions bash` |
-| **Explain mode**  | Show query breakdown + jq filter | `--explain` |
-| **Timing**        | Execution timing | `--time` |
-| **Fuzzy suggest** | Typo correction for fields | Suggests similar field names |
-| **Colorized output** | Syntax-highlighted JSON in terminal | Auto when TTY |
+- exact jq language control: use raw `jq`
+- Python expressions over JSON: use [`jello`](https://github.com/kellyjonbrazil/jello)
+- grep-friendly flattened assignment lines: use [`gron`](https://github.com/tomnomnom/gron)
+- joins, window functions, or relational analytics: use a database or analytics engine
+- production ETL, scheduling, or connectors: use an ETL system
 
----
+## Install
 
-## Why Jonq?
+jonq requires Python 3.9+ and the `jq` command-line tool.
 
-### Jonq vs raw jq
-
-| Task | Raw **jq** filter | **jonq** one-liner |
-|------|------------------|--------------------|
-| Select specific fields | `jq '.[]&#124;{name:.name,age:.age}'` | `jonq data.json "select name, age"` |
-| Filter rows | `jq '.[]&#124;select(.age > 30)&#124;{name,age}'` | `... "select name, age if age > 30"` |
-| Sort + limit | `jq 'sort_by(.age) &#124; reverse &#124; .[0:2]'` | `... "select name, age sort age desc 2"` |
-| Standalone limit | `jq '.[0:5]'` | `... "select * limit 5"` |
-| Distinct values | `jq '[.[].city] &#124; unique'` | `... "select distinct city"` |
-| IN filter | `jq '.[] &#124; select(.city=="NY" or .city=="LA")'` | `... "select * if city in ('NY', 'LA')"` |
-| NOT filter | `jq '.[] &#124; select((.age > 30) &#124; not)'` | `... "select * if not age > 30"` |
-| LIKE filter | `jq '.[] &#124; select(.name &#124; startswith("Al"))'` | `... "select * if name like 'Al%'"` |
-| Uppercase | `jq '.[] &#124; {name: (.name &#124; ascii_upcase)}'` | `... "select upper(name) as name"` |
-| Count items | `jq 'map(select(.age>25)) &#124; length'` | `... "select count(*) as over_25 if age > 25"` |
-| Count distinct | `jq '[.[].city] &#124; unique &#124; length'` | `... "select count(distinct city) as n"` |
-| Group & count | `jq 'group_by(.city) &#124; map({city:.[0].city,count:length})'` | `... "select city, count(*) as count group by city"` |
-| Group & HAVING | `jq 'group_by(.city) &#124; map(select(length>2)) &#124; ...'` | `... "select city, count(*) group by city having count > 2"` |
-| Field expression | `jq '.[] &#124; {name, age_plus: (.age + 10)}'` | `... "select name, age + 10 as age_plus"` |
-| CASE/WHEN | `jq '.[] &#124; if .age>30 then "senior" else "junior" end'` | `... "select case when age > 30 then 'senior' else 'junior' end as level"` |
-| COALESCE | `jq '.[] &#124; {d: (.nick // .name)}'` | `... "select coalesce(nickname, name) as display"` |
-| IS NULL | `jq '.[] &#124; select(.email != null)'` | `... "select * if email is not null"` |
-| String concat | `jq '.[] &#124; {f: (.first + " " + .last)}'` | `... "select first &#124;&#124; ' ' &#124;&#124; last as full"` |
-| Type cast | `jq '.[] &#124; {p: (.price &#124; tonumber)}'` | `... "select float(price) as p"` |
-| Date convert | `jq '.[] &#124; {d: (.ts &#124; todate)}'` | `... "select todate(ts) as d"` |
-
-**Take-away:** a single `jonq` string replaces many pipes and brackets while still producing pure jq under the hood.
-
----
-
-### Where jonq fits
-
-- Use **jonq** when the source of truth is still raw JSON and you need to inspect fields, paths, filters, or nested values quickly.
-- Use **raw jq** when you already know the exact jq filter you want and do not need the friendlier syntax.
-- Use **jello** when you want to process JSON with Python expressions from the CLI.
-- Use **gron** when you want to flatten JSON into grep-friendly assignment lines.
-
-**TL;DR:** jonq is the "understand and shape this JSON from the terminal" step, not a database or ETL layer.
-
----
-
-## Installation
-
-**Supported Platforms**: Linux, macOS, and Windows with WSL.
-
-### Prerequisites
-
-- Python 3.9+
-- `jq` command line tool installed (https://stedolan.github.io/jq/download/)
-
-### Setup
-
-**From PyPI**
 ```bash
 pip install jonq
 ```
 
-**From source**
+From source:
+
 ```bash
 git clone https://github.com/duriantaco/jonq.git
-cd jonq && pip install -e .
+cd jonq
+pip install -e .
 ```
 
-### Quick Start
+Check that `jq` is available:
 
 ```bash
-# Create a simple JSON file
-echo '[{"name":"Alice","age":30,"city":"New York"},{"name":"Bob","age":25,"city":"LA"}]' > data.json
+jq --version
+```
 
-# Select fields
-jonq data.json "select name, age if age > 25"
-# Output: [{"name":"Alice","age":30}]
+## Quick Start
 
-# Table output
-jonq data.json "select name, age, city" -t
+Create a sample file:
 
-# Pipe from stdin (no '-' needed)
-curl -s https://api.example.com/data | jonq "select id, name" -t
+```bash
+cat > users.json <<'JSON'
+[
+  {"id": 1, "name": "Alice", "age": 30, "city": "New York"},
+  {"id": 2, "name": "Bob", "age": 25, "city": "Los Angeles"},
+  {"id": 3, "name": "Charlie", "age": 35, "city": "Chicago"}
+]
+JSON
+```
 
-# Conditional expressions
-jonq data.json "select name, case when age > 28 then 'senior' else 'junior' end as level" -t
+Select fields:
 
-# Null handling
-jonq data.json "select coalesce(nickname, name) as display"
+```bash
+jonq users.json "select name, age"
+```
 
-# Type casting
-jonq data.json "select name, str(age) as age_str"
+Filter rows:
 
-# String concatenation
-jonq data.json "select name || ' (' || city || ')' as label"
+```bash
+jonq users.json "select name, age if age > 30"
+```
 
-# YAML output
-jonq data.json "select name, age" -f yaml
+Render a table:
 
-# See what jq jonq generates
-jonq data.json "select name, age if age > 25" --explain
+```bash
+jonq users.json "select name, city, age sort age desc" -t
+```
+
+Get unique values:
+
+```bash
+jonq users.json "select distinct city"
+```
+
+Aggregate:
+
+```bash
+jonq users.json "select count(*) as total, avg(age) as avg_age"
+```
+
+See what jq will run:
+
+```bash
+jonq users.json "select name if age > 30" --explain
 ```
 
 ## Query Syntax
 
-```
-select [distinct] <fields> [from <path>] [if <condition>] [group by <fields> [having <condition>]] [sort <field> [asc|desc]] [limit N]
-```
-
-Where:
-* `distinct` - Optional, returns unique rows
-* `<fields>` - Comma-separated: fields, aliases, `CASE/WHEN`, `coalesce()`, functions, aggregations, expressions
-* `from <path>` - Optional source path for nested data
-* `if <condition>` - Optional filter (supports `=`, `!=`, `>`, `<`, `>=`, `<=`, `and`, `or`, `not`, `in`, `like`, `between`, `contains`, `is null`, `is not null`)
-* `group by <fields>` - Optional grouping by one or more fields
-* `having <condition>` - Optional filter on grouped results
-* `sort <field> [asc|desc]` - Optional ordering
-* `limit N` - Optional result count limit
-
-## Examples
-
-Given this JSON (`simple.json`):
-
-```json
-[
-  { "id": 1, "name": "Alice",   "age": 30, "city": "New York"    },
-  { "id": 2, "name": "Bob",     "age": 25, "city": "Los Angeles" },
-  { "id": 3, "name": "Charlie", "age": 35, "city": "Chicago"     }
-]
+```text
+select [distinct] <fields>
+  [from <path>]
+  [if <condition>]
+  [group by <fields> [having <condition>]]
+  [sort <field> [asc|desc]]
+  [limit N]
 ```
 
-### Selection
-```bash
-jonq simple.json "select *"                    # all fields
-jonq simple.json "select name, age"            # specific fields
-jonq simple.json "select name as full_name"    # with alias
-```
-
-### DISTINCT
-```bash
-jonq simple.json "select distinct city"
-# [{"city":"Chicago"},{"city":"Los Angeles"},{"city":"New York"}]
-```
-
-### Filtering
-```bash
-jonq simple.json "select name, age if age > 30"
-jonq simple.json "select name if age > 25 and city = 'New York'"
-jonq simple.json "select name if age > 30 or city = 'Los Angeles'"
-jonq simple.json "select name if age between 25 and 30"
-```
-
-### IN Operator
-```bash
-jonq simple.json "select * if city in ('New York', 'Chicago')"
-# [{"id":1,"name":"Alice","age":30,"city":"New York"},{"id":3,"name":"Charlie","age":35,"city":"Chicago"}]
-```
-
-### NOT Operator
-```bash
-jonq simple.json "select * if not age > 30"
-# [{"id":1,"name":"Alice","age":30,"city":"New York"},{"id":2,"name":"Bob","age":25,"city":"Los Angeles"}]
-```
-
-### LIKE Operator
-```bash
-jonq simple.json "select * if name like 'Al%'"     # starts with "Al"
-jonq simple.json "select * if name like '%ice'"     # ends with "ice"
-jonq simple.json "select * if name like '%li%'"     # contains "li"
-```
-
-### Sorting and Limiting
-```bash
-jonq simple.json "select name, age sort age desc"
-jonq simple.json "select name, age sort age desc 2"   # sort + inline limit
-jonq simple.json "select * limit 2"                    # standalone limit
-```
-
-### Aggregation
-```bash
-jonq simple.json "select sum(age) as total_age"
-jonq simple.json "select avg(age) as average_age"
-jonq simple.json "select count(*) as total"
-jonq simple.json "select count(distinct city) as unique_cities"
-```
-
-### GROUP BY and HAVING
-```bash
-jonq simple.json "select city, count(*) as cnt group by city"
-jonq simple.json "select city, avg(age) as avg_age group by city"
-jonq simple.json "select city, count(*) as cnt group by city having cnt > 0"
-```
-
-### String Functions
-```bash
-jonq simple.json "select upper(name) as name_upper"
-# [{"name_upper":"ALICE"},{"name_upper":"BOB"},{"name_upper":"CHARLIE"}]
-
-jonq simple.json "select lower(city) as city_lower"
-jonq simple.json "select length(name) as name_len"
-```
-
-### Math Functions
-```bash
-jonq simple.json "select round(age) as rounded_age"
-jonq simple.json "select abs(age) as abs_age"
-jonq simple.json "select ceil(age) as ceil_age"
-jonq simple.json "select floor(age) as floor_age"
-```
-
-### Nested JSON
+Examples:
 
 ```bash
-# nested field access
-jonq nested.json "select name, profile.address.city"
-
-# from: select from nested arrays
-jonq complex.json "select name, type from products"
-
-# boolean logic with nested fields
-jonq nested.json "select name if profile.address.city = 'New York' or orders[0].price > 1000"
+jonq users.json "select *"
+jonq users.json "select name as full_name, age"
+jonq users.json "select name if city in ('New York', 'Chicago')"
+jonq users.json "select name if not age > 30"
+jonq users.json "select name if name like 'Al%'"
+jonq users.json "select name if age between 25 and 35"
+jonq users.json "select city, count(*) as count group by city"
+jonq users.json "select city, avg(age) as avg_age group by city having avg_age > 30"
+jonq users.json "select name, age sort age desc limit 2"
 ```
 
-### CASE/WHEN Expressions
+## Fields and Expressions
+
+Select nested fields with dot notation:
+
 ```bash
-jonq simple.json "select name, case when age > 30 then 'senior' when age > 25 then 'mid' else 'junior' end as level"
-# [{"name":"Alice","level":"mid"},{"name":"Bob","level":"junior"},{"name":"Charlie","level":"senior"}]
+jonq users.json "select profile.email, profile.address.city"
 ```
 
-### COALESCE
+Select from nested arrays with `from`:
+
 ```bash
-jonq data.json "select coalesce(nickname, name) as display_name"
-# Falls back to name when nickname is null
-
-# Works with nested functions
-jonq data.json "select coalesce(todate(timestamp), 'unknown') as date"
+jonq orders.json "select id, total from orders"
+jonq users.json "select order_id, price from [].orders if price > 100"
 ```
 
-### IS NULL / IS NOT NULL
+Use array indexes:
+
 ```bash
-jonq data.json "select name if email is not null"
-jonq data.json "select name if nickname is null"
+jonq users.json "select name, orders[0].item as first_order"
 ```
 
-### String Concatenation
+Use functions and expressions:
+
 ```bash
-# Using || (SQL standard)
-jonq simple.json "select name || ' from ' || city as label"
-
-# Using + (also works)
-jonq simple.json "select name + ' from ' + city as label"
+jonq users.json "select upper(name) as name, str(age) as age"
+jonq users.json "select name || ' (' || city || ')' as label"
+jonq users.json "select age * 2 + 3 as score"
+jonq users.json "select coalesce(nickname, name) as display"
+jonq users.json "select case when age > 30 then 'senior' else 'junior' end as segment"
 ```
 
-### Type Casting
-```bash
-jonq data.json "select int(price) as price"        # string → integer
-jonq data.json "select float(amount) as amount"     # string → float
-jonq data.json "select str(code) as code"           # number → string
-jonq data.json "select type(value) as t"            # get type name
-```
+Common functions:
 
-### Date/Time Functions
-```bash
-jonq data.json "select todate(timestamp) as date"   # epoch → ISO date
-jonq data.json "select date(created_at) as d"       # alias for todate
-```
-
-### Arithmetic Expressions
-```bash
-jonq simple.json "select name, age + 10 as age_plus_10"
-```
+| Category | Functions |
+|----------|-----------|
+| Strings | `upper`, `lower`, `length`, `trim`, `ltrim`, `rtrim` |
+| Math | `round`, `abs`, `ceil`, `floor` |
+| Casting | `int`, `float`, `str`, `string`, `type` |
+| Dates | `todate`, `fromdate`, `date`, `timestamp` |
+| JSON/arrays | `keys`, `values`, `tojson`, `fromjson`, `reverse`, `sort`, `unique`, `flatten` |
+| Nulls | `coalesce`, `is null`, `is not null` |
 
 ## Output Formats
 
-### Table Output
-```bash
-jonq simple.json "select name, age, city" -t
-# name    | age | city
-# --------|-----|-------------
-#  Alice   | 30  | New York
-#  Bob     | 25  | Los Angeles
-#  Charlie | 35  | Chicago
-```
-
-### CSV Output
-```bash
-jonq simple.json "select name, age" --format csv > output.csv
-```
-
-### JSONL Output
-```bash
-jonq simple.json "select name, age" --format jsonl > output.jsonl
-```
-
-### YAML Output
-```bash
-jonq simple.json "select name, age" --format yaml
-# - name: Alice
-#   age: 30
-# - name: Bob
-#   age: 25
-```
-
-### Python API
-
-```python
-from jonq import compile_query, query
-
-data = [
-    {"name": "Alice", "age": 30, "city": "New York"},
-    {"name": "Bob", "age": 25, "city": "LA"},
-]
-
-compiled = compile_query("select name, city if age > 26")
-result = query(data, compiled)
-print(result)
-```
-
-Output:
-
-```python
-[{"name": "Alice", "city": "New York"}]
-```
-
-If you want metadata such as the generated jq filter, use `execute(...)` instead of `query(...)`.
-
-Repeated identical filters reuse a live jq worker in long-lived Python processes, which reduces jq startup overhead in loops and services.
-
-## Streaming Mode
-
-For processing large root-array JSON files more efficiently:
+JSON is the default:
 
 ```bash
-jonq large.json "select name, age" --stream
+jonq users.json "select name, age"
 ```
 
-Chunk execution stays in memory and reuses the same jq worker for the generated filter instead of writing chunk temp files and starting a fresh jq subprocess for every chunk.
+Table:
 
-## Path Explorer
+```bash
+jonq users.json "select name, age, city" -t
+jonq users.json "select name, age, city" --format table
+```
 
-Run `jonq` with just a file (no query) to inspect nested JSON paths before writing a query:
+CSV:
+
+```bash
+jonq users.json "select name, age" --format csv > users.csv
+```
+
+JSONL:
+
+```bash
+jonq users.json "select name, age" --format jsonl > users.jsonl
+```
+
+YAML:
+
+```bash
+jonq users.json "select name, age" --format yaml
+```
+
+## Input Sources
+
+Local file:
+
+```bash
+jonq data.json "select id, name"
+```
+
+Piped stdin:
+
+```bash
+curl -s https://api.example.com/users | jonq "select id, name" -t
+cat data.json | jonq - "select id, name"
+```
+
+URL:
+
+```bash
+jonq https://api.example.com/users.json "select id, email"
+```
+
+Glob:
+
+```bash
+jonq 'logs/*.json' "select * if level = 'error'"
+```
+
+NDJSON file:
+
+```bash
+jonq app.ndjson "select level, message if level = 'error'"
+```
+
+Follow live NDJSON from stdin:
+
+```bash
+tail -f app.ndjson | jonq --follow "select level, message if level = 'error'" -t
+```
+
+## Inspect Before Querying
+
+Run jonq with no query to inspect paths, inferred types, sample values, and a suggested query:
 
 ```bash
 jonq data.json
 ```
 
-Output:
-```
+Example output:
+
+```text
 data.json  (array, sampled 3 items)
 
 Paths:
-  id             int               1
-  name           str               "Alice"
-  age            int               30
-  city           str               "New York"
-  orders[]       array[object]
-  orders[].id    int               1
-  orders[].item  str               "Laptop"
+  id    int  1
+  name  str  "Alice"
+  age   int  30
+  city  str  "New York"
 
 Sample:
-  { "id": 1, "name": "Alice", "age": 30, "city": "New York", "orders": [{ "id": 1, "item": "Laptop" }] }
+  {
+    "id": 1,
+    "name": "Alice",
+    "age": 30,
+    "city": "New York"
+  }
 
-Tip: jonq data.json "select name, orders[].item"
+Tip: jonq data.json "select id, name"
 ```
 
-## Interactive REPL
+## Streaming and Watch Modes
 
-Launch an interactive session with tab completion and persistent history:
+Streaming mode processes root-array JSON in chunks:
 
 ```bash
-jonq -i data.json
+jonq large.json "select id, name if active = true" --stream
 ```
 
-```
-jonq interactive mode — querying data.json
-Type a query, or 'quit' to exit. Tab completes field names.
-Example: select name, age if age > 30
+Streaming is for row-wise queries. It intentionally rejects queries that require global input state, including `group by`, `sort`, `distinct`, `limit`, `count`, `sum`, `avg`, `min`, `max`, and `count(distinct ...)`.
 
-jonq> select name, age
-[{"name":"Alice","age":30},{"name":"Bob","age":25}]
-jonq> select * if age > 28
-[{"id":1,"name":"Alice","age":30,"city":"New York"}]
-jonq> quit
-```
-
-Features:
-- **Tab completion** for field names and SQL keywords
-- **Persistent history** saved to `~/.jonq_history`
-- **Up/down arrow** to recall previous queries
-
-## Watch Mode
-
-Re-run a query automatically whenever the file changes:
+Watch mode reruns a query when a file changes:
 
 ```bash
 jonq data.json "select name, age" --watch
 ```
 
-Because watch mode reruns the same filter repeatedly inside one loop, jonq reuses a live jq worker to reduce refresh overhead.
-
-## Multiple Input Sources
-
-### URL Fetch
-```bash
-jonq https://api.example.com/users.json "select name, email"
-```
-
-### Multi-File Glob
-```bash
-jonq 'logs/*.json' "select * if level = 'error'"
-```
-
-### Stdin
-```bash
-# Auto-detected — no '-' needed
-curl -s https://api.example.com/data | jonq "select id, name"
-
-# Explicit stdin still works
-cat data.json | jonq - "select name, age"
-```
-
-## Follow Mode
-
-Stream NDJSON from stdin line-by-line, applying the query to each object as it arrives:
+Interactive mode provides history and field-aware completion:
 
 ```bash
-tail -f app.log | jonq --follow "select level, message if level = 'error'" -t
+jonq -i data.json
 ```
 
-Only matching lines are printed. Non-matching lines are silently skipped.
+## Python API
 
-## Auto-detect NDJSON
+Use `query(...)` when you want Python data back:
 
-jonq auto-detects NDJSON (newline-delimited JSON) files. No flag needed:
+```python
+from jonq import query
 
-```bash
-jonq data.ndjson "select name, age if age > 25"
+data = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+]
+
+rows = query(data, "select name if age > 26")
+print(rows)
 ```
 
-You can still force it with `--ndjson` if needed. `--ndjson` cannot be combined with `--stream`.
+Use `execute(...)` when you want text output plus metadata:
 
-## Fuzzy Field Suggestions
+```python
+from jonq import execute
 
-When you mistype a field name, jonq suggests similar fields:
-
+result = execute(data, "select name, age", format="jsonl")
+print(result.text)
+print(result.compiled.jq_filter)
 ```
-$ jonq data.json "select nme, agge"
-Field(s) 'nme, agge' not found. Available fields: age, city, id, name. Did you mean: 'nme' -> name; 'agge' -> age?
+
+Compile once and reuse:
+
+```python
+from jonq import compile_query, query
+
+compiled = compile_query("select name if age > 25")
+print(query([{"name": "Alice", "age": 30}], compiled))
 ```
+
+Async helpers are also available: `query_async(...)` and `execute_async(...)`.
 
 ## CLI Options
 
 | Option | Description |
 |--------|-------------|
-| `--format, -f` | Output format: `json` (default), `jsonl`, `csv`, `table`, `yaml` |
+| `-f, --format {json,jsonl,csv,table,yaml}` | Output format |
 | `-t, --table` | Shorthand for `--format table` |
-| `--stream, -s` | Process row-wise root-array queries in memory-friendly chunks |
-| `--ndjson` | Force NDJSON mode (auto-detected by default) |
-| `--follow` | Stream NDJSON from stdin line-by-line |
-| `--limit, -n N` | Limit rows post-query |
-| `--out, -o PATH` | Write output to file |
-| `--jq` | Print generated jq filter and exit |
-| `--explain` | Show parsed query breakdown and generated jq filter |
-| `--time` | Print execution timing to stderr |
-| `--pretty, -p` | Pretty-print JSON output |
-| `--watch, -w` | Re-run query when file changes |
-| `--no-color` | Disable colorized output |
-| `--completions SHELL` | Print shell completion script (`bash`, `zsh`, `fish`) |
-| `--version` | Show the installed jonq version |
-| `-i <file>` | Interactive query mode (REPL) with tab completion |
-| `-h, --help` | Show help message |
+| `-s, --stream` | Chunk-safe streaming for root-array JSON |
+| `--ndjson` | Force NDJSON mode |
+| `--follow` | Process NDJSON from stdin line-by-line |
+| `-n, --limit N` | Limit rows after query execution |
+| `-o, --out PATH` | Write output to a file |
+| `--jq` | Print the generated jq filter and exit |
+| `--explain` | Show parsed query details and generated jq |
+| `--time` | Print parse/execute/format timing to stderr |
+| `-p, --pretty` | Pretty-print JSON output |
+| `-w, --watch` | Rerun when the input file changes |
+| `--no-color` | Disable terminal color |
+| `--completions {bash,zsh,fish}` | Print shell completions |
+| `--version` | Print version |
+| `-i FILE, --interactive FILE` | Start the REPL |
 
 ## Shell Completions
-
-Generate completion scripts for your shell:
 
 ```bash
 # Bash
@@ -577,48 +387,35 @@ eval "$(jonq --completions zsh)"
 jonq --completions fish > ~/.config/fish/completions/jonq.fish
 ```
 
-## Colorized Output
-
-When outputting to a terminal, jonq auto-pretty-prints and colorizes JSON. Pipe to a file or use `--no-color` to disable.
-
 ## Troubleshooting
 
-### Common Errors
+- **`jq` is not found**: Install jq and make sure it is on `PATH`.
 
-**Command 'jq' not found** - Make sure jq is installed and in your PATH. Install: https://stedolan.github.io/jq/download/
+- **No query was provided**: Run `jonq data.json` to inspect the file, or pass a query such as `jonq data.json "select *"`.
 
-**Invalid JSON in file** - Check your JSON file for syntax errors. Use a JSON validator.
+- **A field is missing or misspelled**: jonq validates top-level fields for normal file inputs and suggests close matches.
 
-**Syntax error in query** - Verify your query follows the correct syntax. Check field names and quotes.
+- **Streaming mode rejected a query**: Use non-streaming mode for global operations like aggregation, grouping, sorting, distinct, or limit.
 
-**Runtime jq error** - Errors like `Cannot iterate over string` or `Cannot iterate over null` are surfaced immediately. Adjust the field path or inspect the input with `jonq data.json`.
-
-**No results returned** - Verify your condition isn't filtering out all records. Check field name casing.
+- **The generated jq looks surprising**: Run the same command with `--explain` to see the parsed query and generated jq filter.
 
 ## Known Limitations
 
-* Performance: For very large JSON files (100MB+), processing may still be slow. `--stream` is more memory-friendly now, but jonq is still not an analytical engine.
-* Advanced jq Features: Some advanced jq features (recursive descent, custom filters) aren't exposed in the jonq syntax.
-* Custom Functions: User-defined functions aren't supported.
-* Joins: Cross-file joins are not supported — use a database for relational queries.
-* Window Functions: Not supported — use an analytical query engine for analytical queries.
+- jonq exposes a practical subset of jq, not the full jq language.
+- Streaming mode supports row-wise queries only.
+- Cross-file joins, window functions, and relational analytics are out of scope.
+- URL fetch is a convenience feature, not a full HTTP client.
+- Very large files can still be slow if the query requires full-input state.
 
-## Docs
+## Documentation
 
-Full documentation: https://jonq.readthedocs.io/en/latest/
-
-See also: [SYNTAX.md](SYNTAX.md) for the complete syntax reference.
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
+- Full docs: https://jonq.readthedocs.io/en/latest/
+- Syntax reference: [SYNTAX.md](SYNTAX.md)
+- Usage examples: [USAGE.md](USAGE.md)
+- Contributing: [CONTRIBUTIONS.md](CONTRIBUTIONS.md)
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+jonq is licensed under the MIT License. See [License](License).
 
-### Misc.
-
-- **jq**: This tool depends on the [jq command-line JSON processor](https://stedolan.github.io/jq/), which is licensed under the MIT License. jq is copyright (C) 2012 Stephen Dolan.
-
-The jq tool itself is not included in this package - users need to install it separately.
+jonq depends on the [jq command-line JSON processor](https://stedolan.github.io/jq/). jq is licensed under the MIT License and is not bundled with jonq.

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -5,6 +5,10 @@ The general form of a jonq query is:
 select [distinct] <fields> [from <path>] [if <condition>] [group by <fields> [having <condition>]] [sort <field> [asc|desc]] [limit N]
 ```
 
+jonq query syntax is for JSON extraction and reshaping. CLI behavior such as
+output formats, streaming, watch mode, and shell completions is configured with
+command-line flags rather than inside the query string.
+
 ## SELECT Statement
 Every jonq query must begin with select, followed by one or more fields to retrieve.
 
@@ -42,6 +46,14 @@ select name, profile.age, profile.address.city
 Use square brackets to access array elements:
 ```bash
 select name, orders[0].item, scores[1]
+```
+
+#### Nested Arrays with FROM
+Use `from <path>` when each output row should come from a nested array:
+```bash
+select order_id, item, price from [].orders
+select order_id, item, price from [].orders if price > 800
+select type, name from products
 ```
 
 #### Fields with Special Characters
@@ -179,28 +191,28 @@ select count(distinct status) as status_count
 Calculate the sum of numeric values:
 ```bash
 select sum(age) as total_age
-select sum(orders.price) as total_sales
+select sum(price) as total_sales from [].orders
 ```
 
 ### avg
 Calculate the average of numeric values:
 ```bash
 select avg(age) as average_age
-select avg(orders.price) as average_price
+select avg(price) as average_price from [].orders
 ```
 
 ### max
 Find the maximum value:
 ```bash
 select max(age) as oldest
-select max(orders.price) as highest_price
+select max(price) as highest_price from [].orders
 ```
 
 ### min
 Find the minimum value:
 ```bash
 select min(age) as youngest
-select min(orders.price) as lowest_price
+select min(price) as lowest_price from [].orders
 ```
 
 ## String Functions
@@ -325,8 +337,8 @@ select type(value) as val_type
 
 | Function | Description | jq equivalent |
 |----------|-------------|---------------|
-| `todate(x)` / `date(x)` | Epoch → ISO 8601 | `todate` |
-| `fromdate(x)` / `timestamp(x)` | ISO 8601 → epoch | `fromdate` |
+| `todate(x)` / `date(x)` | Epoch -> ISO 8601 | `todate` |
+| `fromdate(x)` / `timestamp(x)` | ISO 8601 -> epoch | `fromdate` |
 
 ```bash
 select todate(created_at) as date
@@ -343,20 +355,20 @@ Null-safe: returns `null` instead of crashing on null input.
 | `values(x)` | Object values |
 | `trim(x)` | Strip leading/trailing spaces |
 | `ltrim(x)` / `rtrim(x)` | Strip left/right spaces |
-| `tojson(x)` | Value → JSON string |
-| `fromjson(x)` | JSON string → value |
+| `tojson(x)` | Value -> JSON string |
+| `fromjson(x)` | JSON string -> value |
 | `reverse(x)` | Reverse array |
 | `sort(x)` | Sort array |
 | `unique(x)` | Unique array values |
 | `flatten(x)` | Flatten nested arrays |
-| `to_entries(x)` | Object → `[{key, value}]` |
-| `from_entries(x)` | `[{key, value}]` → object |
+| `to_entries(x)` | Object -> `[{key, value}]` |
+| `from_entries(x)` | `[{key, value}]` -> object |
 
 ## Arithmetic Expressions
 jonq supports basic arithmetic expressions:
 ```bash
 select name, age + 10 as age_plus_10
-select name, max(orders.price) - min(orders.price) as price_range
+select name, max(orders[].price) - min(orders[].price) as price_range
 ```
 
 ## Complex Query Examples
@@ -373,12 +385,12 @@ select profile.address.city, count(*) as user_count, avg(profile.age) as avg_age
 
 ### Aggregation with Filtering
 ```bash
-select sum(orders.price) as total_sales if orders.price > 100
+select sum(price) as total_sales from [].orders if price > 100
 ```
 
 ### Combining Multiple Features
 ```bash
-select name, profile.age, count(orders) as order_count if profile.age > 25 group by profile.address.city sort order_count desc 5
+select profile.address.city, count(*) as user_count, avg(profile.age) as avg_age if profile.age > 25 group by profile.address.city sort user_count desc 5
 ```
 
 ### Quoted String Values
@@ -400,3 +412,10 @@ jonq automatically handles null values in JSON input:
 ```bash
 select name, age if age is not null
 ```
+
+## Streaming Compatibility
+
+The `--stream` CLI flag supports row-wise queries over root-array JSON. It is
+compatible with field selection, expressions, and `if` filters. It rejects
+aggregations, `group by`, `sort`, `distinct`, and `limit` because those require
+global input state.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,545 +1,184 @@
-# USAGE GUIDE
+# jonq Usage Guide
 
-## simple.json
+This file is a compact, copyable guide. The full documentation lives in
+`docs/source/` and at https://jonq.readthedocs.io.
 
-```json
+## Sample Data
+
+Most examples below use this file:
+
+```bash
+cat > users.json <<'JSON'
 [
   {"id": 1, "name": "Alice", "age": 30, "city": "New York"},
   {"id": 2, "name": "Bob", "age": 25, "city": "Los Angeles"},
   {"id": 3, "name": "Charlie", "age": 35, "city": "Chicago"}
 ]
+JSON
 ```
-1. Basic Selection
 
-### Select all fields:
+Nested examples use:
 
-Input: `jonq json_test_files/simple.json "select *"`
-
-```json
+```bash
+cat > nested.json <<'JSON'
 [
   {
     "id": 1,
     "name": "Alice",
-    "age": 30,
-    "city": "New York"
-  },
-  {
-    "id": 2,
-    "name": "Bob",
-    "age": 25,
-    "city": "Los Angeles"
-  },
-  {
-    "id": 3,
-    "name": "Charlie",
-    "age": 35,
-    "city": "Chicago"
-  }
-]
-```
-
-### Select specific fields:
-
-Input: `jonq json_test_files/simple.json "select name, age"`
-
-```json
-[
-    {
-    "name": "Alice",
-    "age": 30
-  },
-  {
-    "name": "Bob",
-    "age": 25
-  },
-  {
-    "name": "Charlie",
-    "age": 35
-  }
-]
-```
-2. Filtering with Conditions
-
-### Basic filtering:
-
-Input: `jonq json_test_files/simple.json "select name, age if age > 30"`
-
-```json
-[{
-    "name": "Charlie",
-    "age": 35
-  }
-]
-```
-
-3. Sorting and Limiting
-
-### Sort descending with limit:
-
-Input: `jonq json_test_files/simple.json "select name, age sort age desc 2"`
-
-```json
-[
-{
-    "name": "Charlie",
-    "age": 35
-  },
-  {
-    "name": "Alice",
-    "age": 30
-  }
-]
-```
-
-4. Aggregation Functions
-
-### Sum: 
-
-Input: `jonq json_test_files/simple.json "select sum(age) as total_age"`
-
-```json
-{
-  "total_age": 90
-}
-```
-
-### Average:
-
-Input: `jonq json_test_files/simple.json "select avg(age) as total_age"`
-
-```json
-{
-  "total_age": 30
-}
-```
-
-### Count:
-
-Input: `jonq json_test_files/simple.json "select count(age) as total_age"`
-
-```json
-{
-  "total_age": 3
-}
-```
-
-### Min/Max:
-
-Input: `jonq simple.json "select min(age) as youngest, max(age) as oldest"`
-
-```json
-{
-  "youngest": 25,
-  "oldest": 35
-}
-```
-
-5. Grouping and Having
-
-### Group by single field:
-
-Input: `jonq simple.json "select city, count(*) as count group by city"`
-
-```json
-[
-  {
-    "city": "Chicago",
-    "count": 1
-  },
-  {
-    "city": "Los Angeles",
-    "count": 1
-  },
-  {
-    "city": "New York",
-    "count": 1
-  }
-]
-```
-
-### Group by with aggregation:
-
-Input: `jonq simple.json "select city, avg(age) as avg_age group by city"`
-
-```json
-[
-  {
-    "city": "Chicago",
-    "avg_age": 35
-  },
-  {
-    "city": "Los Angeles",
-    "avg_age": 25
-  },
-  {
-    "city": "New York",
-    "avg_age": 30
-  }
-]
-```
-
-### Group by with HAVING clause:
-
-Input: `jonq simple.json "select city, count(*) as count group by city having count >= 1"`
-
-```json
-[
-  {
-    "city": "Chicago",
-    "count": 1
-  },
-  {
-    "city": "Los Angeles",
-    "count": 1
-  },
-  {
-    "city": "New York",
-    "count": 1
-  }
-]
-```
-
-=====================================================
-
-## nested.json
-
-```json
-[
-  {
-    "id": 1, "name": "Alice",
-    "profile": {
-      "age": 30,
-      "address": {"city": "New York", "zip": "10001"}
-    },
+    "profile": {"age": 30, "address": {"city": "New York"}},
     "orders": [
       {"order_id": 101, "item": "Laptop", "price": 1200},
       {"order_id": 102, "item": "Phone", "price": 800}
     ]
   },
   {
-    "id": 2, "name": "Bob",
-    "profile": {
-      "age": 25,
-      "address": {"city": "Los Angeles", "zip": "90001"}
-    },
+    "id": 2,
+    "name": "Bob",
+    "profile": {"age": 25, "address": {"city": "Los Angeles"}},
     "orders": [
       {"order_id": 103, "item": "Tablet", "price": 500}
     ]
   }
 ]
+JSON
 ```
 
-1. Basic Selection
+## Inspect JSON First
 
-### Access nested fields:
+Run jonq with no query to see paths, types, sample values, and a suggested query:
 
-Input: `jonq json_test_files/nested.json "select name, profile.age"` 
-
-```json
-[
-    {
-    "name": "Alice",
-    "age": 30
-  },
-  {
-    "name": "Bob",
-    "age": 25
-  }
-]
+```bash
+jonq users.json
 ```
 
-### Access deeply nested fields:
+## Select Fields
 
-Input: `jonq json_test_files/nested.json "select name, profile.address.city"` 
-
-```json
-[
-{
-    "name": "Alice",
-    "city": "New York"
-  },
-  {
-    "name": "Bob",
-    "city": "Los Angeles"
-  }
-]
+```bash
+jonq users.json "select *"
+jonq users.json "select name, age"
+jonq users.json "select name as full_name, age as years"
 ```
 
-2. Array Operations
+## Filter Rows
 
-### Count array items:
-
-Input: `jonq json_test_files/nested.json "select name, count(orders) as order_count"`
-
-```json
-[
-  {
-    "name": "Alice",
-    "order_count": 2
-  },
-  {
-    "name": "Bob",
-    "order_count": 1
-  }
-]
+```bash
+jonq users.json "select name, age if age > 30"
+jonq users.json "select name if city = 'New York'"
+jonq users.json "select name if city in ('New York', 'Chicago')"
+jonq users.json "select name if not age > 30"
+jonq users.json "select name if name like 'Al%'"
+jonq users.json "select name if age between 25 and 35"
 ```
 
-### Access array elements:
+## Sort, Limit, and Distinct
 
-Input: `jonq nested.json "select name, orders[0].item as first_item"`
-
-```json
-[
-  {
-    "name": "Alice",
-    "first_item": "Laptop"
-  },
-  {
-    "name": "Bob",
-    "first_item": "Tablet"
-  }
-]
+```bash
+jonq users.json "select name, age sort age desc"
+jonq users.json "select name, age sort age desc limit 2"
+jonq users.json "select * limit 2"
+jonq users.json "select distinct city"
 ```
 
-### Filter by array properties:
+## Aggregate and Group
 
-Input: `jonq nested.json "select name if orders[0].price > 1000"`
-
-```json
-[
-  {
-    "name": "Alice"
-  }
-]
+```bash
+jonq users.json "select count(*) as total"
+jonq users.json "select sum(age) as total_age"
+jonq users.json "select avg(age) as avg_age"
+jonq users.json "select count(distinct city) as unique_cities"
+jonq users.json "select city, count(*) as count group by city"
+jonq users.json "select city, avg(age) as avg_age group by city having avg_age > 30"
 ```
 
-3. Grouping and Having
+## Expressions and Functions
 
-### Group by with nested fields:
-
-Input: `jonq nested.json "select profile.address.city, avg(profile.age) as avg_age group by profile.address.city"`
-
-```json
-[
-  {
-    "city": "Los Angeles",
-    "avg_age": 25
-  },
-  {
-    "city": "New York",
-    "avg_age": 30
-  }
-]
+```bash
+jonq users.json "select upper(name) as name"
+jonq users.json "select name || ' from ' || city as label"
+jonq users.json "select age * 2 + 3 as score"
+jonq users.json "select str(age) as age"
+jonq users.json "select case when age > 30 then 'senior' else 'junior' end as segment"
+jonq users.json "select coalesce(nickname, name) as display"
 ```
 
-### Group by with HAVING on aggregated value:
+## Nested Objects and Arrays
 
-Input: `jonq nested.json "select profile.address.city, avg(profile.age) as avg_age group by profile.address.city having avg_age > 25"`
+Nested fields:
 
-```json
-[
-  {
-    "city": "New York",
-    "avg_age": 30
-  }
-]
+```bash
+jonq nested.json "select name, profile.age, profile.address.city"
 ```
 
-### Using FROM clause to query nested arrays:
+Array indexes:
 
-Input: `jonq nested.json "select order_id, item, price from [].orders"`
-
-```json
-[
-  {
-    "order_id": 101,
-    "item": "Laptop",
-    "price": 1200
-  },
-  {
-    "order_id": 102,
-    "item": "Phone",
-    "price": 800
-  },
-  {
-    "order_id": 103,
-    "item": "Tablet",
-    "price": 500
-  }
-]
+```bash
+jonq nested.json "select name, orders[0].item as first_order"
 ```
 
-### Filtering nested arrays with FROM:
+Query array elements with `from`:
 
-Input: `jonq nested.json "select order_id, item, price from [].orders if price > 800"`
-
-```json
-[
-  {
-    "order_id": 101,
-    "item": "Laptop",
-    "price": 1200
-  }
-]
+```bash
+jonq nested.json "select order_id, item, price from [].orders"
+jonq nested.json "select order_id, item, price from [].orders if price > 800"
 ```
 
-=====================================================
+Aggregations inside each row:
 
-## complex.json
-
-```json
-{
-    "company": {
-      "name": "TechCorp Global",
-      "founded": 2005,
-      "headquarters": {
-        "address": "123 Innovation Way",
-        "city": "San Francisco",
-        "country": "USA",
-        "coordinates": {
-          "latitude": 37.7749,
-          "longitude": -122.4194
-        }
-      },
-      "subsidiaries": [
-        {
-          "name": "TechCorp Asia",
-          "founded": 2010,
-          "headquarters": {
-            "city": "Singapore",
-            "country": "Singapore"
-          },
-          "employees": 250,
-          "financials": {
-            "revenue": 42000000,
-            "profit": 8500000
-          }
-        },
-        {
-          "name": "TechCorp Europe",
-          "founded": 2008,
-          "headquarters": {
-            "city": "Berlin",
-            "country": "Germany"
-          },
-          "employees": 300,
-          "financials": {
-            "revenue": 58000000,
-            "profit": 12000000
-          }
-        }
-      ]
-    },
-    "products": [
-      {
-        "id": "P001",
-        "name": "Enterprise Suite",
-        "type": "Software",
-        "launched": 2012,
-        "versions": [
-          {
-            "version": "1.0",
-            "released": "2012-05-15",
-            "pricing": {
-              "monthly": 199.99,
-              "yearly": 1999.99
-            }
-          },
-          {
-            "version": "2.0",
-            "released": "2015-06-30",
-            "pricing": {
-              "monthly": 299.99,
-              "yearly": 2999.99
-            }
-          }
-        ],
-        "customers": [
-          {"id": "C001", "name": "Acme Corp", "industry": "Manufacturing"},
-          {"id": "C002", "name": "Globex", "industry": "Finance"}
-        ]
-      },
-      {
-        "id": "P002",
-        "name": "Security Shield",
-        "type": "Software",
-        "launched": 2015,
-        "versions": [
-          {
-            "version": "1.0",
-            "pricing": {
-              "monthly": 149.99,
-              "yearly": 1499.99
-            }
-          }
-        ],
-        "customers": [
-          {"id": "C001", "name": "Acme Corp", "industry": "Manufacturing"},
-          {"id": "C003", "name": "Initech", "industry": "Technology"}
-        ]
-      }
-    ]
-  }
+```bash
+jonq nested.json "select name, count(orders) as order_count"
 ```
 
-1. Selection
+## Output Formats
 
-### Access multiple levels of nesting:
-
-Input: `jonq complex.json "select company.name, company.headquarters.city"`
-
-```json
-[
-  {
-    "name": "TechCorp Global",
-    "city": "San Francisco"
-  }
-]
+```bash
+jonq users.json "select name, age"                 # JSON
+jonq users.json "select name, age" -t              # table
+jonq users.json "select name, age" --format csv    # CSV
+jonq users.json "select name, age" --format jsonl  # JSONL
+jonq users.json "select name, age" --format yaml   # YAML
 ```
 
-Input: `jonq complex.json "select name, founded from company.subsidiaries[] if founded > 2008"`
+## Input Sources
 
-```json
-[
-  {
-    "name": "TechCorp Asia",
-    "founded": 2010
-  }
-]
+```bash
+jonq data.json "select id, name"
+cat data.json | jonq - "select id, name"
+curl -s https://api.example.com/users | jonq "select id, name"
+jonq 'logs/*.json' "select * if level = 'error'"
+jonq app.ndjson "select level, message if level = 'error'"
+tail -f app.ndjson | jonq --follow "select level, message if level = 'error'" -t
 ```
 
-### Combine aggregation of nested arrays:
+## Streaming
 
-Input: `jonq complex.json "select avg(products[].versions[].pricing.monthly) as avg_price`
+Streaming mode is for row-wise queries over root-array JSON:
 
-```json
-{
-  "avg_price": 216.65666666666667
-}
+```bash
+jonq large.json "select id, name if active = true" --stream
 ```
 
-Input: `jonq complex.json "select sum(company.subsidiaries[].financials.profit) as total_profit"`
+It rejects global operations such as aggregation, grouping, sorting, distinct, and limit because those require the full input.
 
-```json
-{
-  "total_profit": 20500000
-}
+## Debugging Queries
+
+```bash
+jonq users.json "select name if age > 30" --jq
+jonq users.json "select name if age > 30" --explain
+jonq users.json "select name if age > 30" --time
 ```
 
-### Complex queries: 
+## Python API
 
-Input: `jonq complex.json "select name, avg(versions[].pricing.monthly) as avg_monthly_price from products[]"`
+```python
+from jonq import query, execute, compile_query
 
-```json
-[
-  {
-    "name": "Enterprise Suite",
-    "avg_monthly_price": 249.99
-  },
-  {
-    "name": "Security Shield",
-    "avg_monthly_price": 149.99
-  }
-]
+data = [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
+
+rows = query(data, "select name if age > 25")
+
+result = execute(data, "select name", format="jsonl")
+print(result.text)
+
+compiled = compile_query("select name")
+print(query([{"name": "Bob"}], compiled))
 ```
-

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,7 +18,11 @@ Execute a query and return parsed Python data by default.
 - **Parameters:**
   - ``source``: Python object, raw JSON string, or file path
   - ``query`` (str or ``CompiledQuery``)
-- **Returns:** Parsed Python data, or raw text when ``format="json"``, ``format="jsonl"``, or ``format="csv"``
+  - ``format``: ``"python"`` (default), ``"json"``, ``"jsonl"``, or ``"csv"``. The Python API does not render table or YAML output.
+  - ``streaming``: ``True`` for row-wise root-array file queries
+  - ``limit``: optional post-query limit
+  - ``validate``: validate field names against file input when possible
+- **Returns:** Parsed Python data by default, or raw text for ``json``, ``jsonl``, and ``csv`` formats
 
 **execute(source, query, ...)**
 
@@ -27,11 +31,20 @@ Execute a query and return a structured ``QueryResult`` object.
 - **Parameters:**
   - ``source``: Python object, raw JSON string, or file path
   - ``query`` (str or ``CompiledQuery``)
+  - ``format``: ``"json"`` (default), ``"jsonl"``, or ``"csv"``. The Python API does not render table or YAML output.
+  - ``streaming``: ``True`` for row-wise root-array file queries
+  - ``limit``: optional post-query limit
+  - ``validate``: validate field names against file input when possible
 - **Returns:** ``QueryResult`` with ``text``, ``data``, and ``compiled`` metadata
 
 **query_async(...) / execute_async(...)**
 
 Async variants of the high-level execution helpers.
+
+.. note::
+
+   Streaming mode requires a filesystem path and supports row-wise queries only.
+   It rejects aggregations, ``group by``, ``sort``, ``distinct``, and ``limit`` because those need full-input state.
 
 Main Module (jonq.main)
 -----------------------
@@ -44,7 +57,7 @@ The entry point for the jonq command-line tool.
 
 .. code-block:: bash
 
-   jonq <path/to/json_file> "<query>" [--format json|jsonl|csv|table|yaml] [--stream] [--watch] [--jq] [--pretty] [--no-color] [--ndjson] [--limit N] [--out PATH] [--version]
+   jonq <source> "<query>" [--format json|jsonl|csv|table|yaml] [--stream] [--watch] [--jq] [--explain] [--pretty] [--no-color] [--ndjson] [--limit N] [--out PATH] [--version]
 
 Query Parser (jonq.query_parser)
 --------------------------------
@@ -89,7 +102,7 @@ Executor (jonq.executor)
 
 **run_jq(json_file, jq_filter)**
 
-Executes a jq filter against a JSON file (synchronous).
+Executes a jq filter against a JSON file, or executes a filter against raw JSON text when called as ``run_jq(jq_filter, json_text)``.
 
 - **Parameters:**
   - ``json_file`` (str): Path to JSON file
@@ -99,7 +112,7 @@ Executes a jq filter against a JSON file (synchronous).
 
 **run_jq_async(json_file, jq_filter)**
 
-Executes a jq filter against a JSON file (async).
+Async variant of ``run_jq``.
 
 - **Parameters:**
   - ``json_file`` (str): Path to JSON file

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,7 @@ import os
 project = 'jonq'
 copyright = f'{datetime.datetime.now().year}, oha'
 author = 'oha'
-release = '0.2.0'
+release = '0.3.0'
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
@@ -12,7 +12,6 @@ all_extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
-    'sphinx.ext.intersphinx',
     
     'sphinx_copybutton',
     'sphinx_design',
@@ -20,6 +19,9 @@ all_extensions = [
     'sphinxcontrib.mermaid',
     'myst_parser',
 ]
+
+if on_rtd or os.environ.get('JONQ_ENABLE_INTERSPHINX') == '1':
+    all_extensions.append('sphinx.ext.intersphinx')
 
 extensions = []
 
@@ -30,9 +32,11 @@ for extension in all_extensions:
     except ImportError:
         print(f"Warning: Extension {extension} not available, skipping.")
 
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-}
+intersphinx_mapping = (
+    {'python': ('https://docs.python.org/3', None)}
+    if 'sphinx.ext.intersphinx' in extensions
+    else {}
+)
 
 myst_enable_extensions = [
     "colon_fence", 
@@ -76,7 +80,7 @@ html_theme_options = {
     },
     
     "navigation_with_keys": True,
-    "announcement": "jonq v0.2.0 is now available! Check the installation guide for details.",
+    "announcement": "jonq v0.3.0 is now available. Check the usage guide for JSONL, streaming, and Python API examples.",
 }
 
 html_static_path = ['_static']

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -20,7 +20,15 @@ Setting Up Development Environment
 
       python -m venv venv
       source venv/bin/activate  # On Windows: venv\Scripts\activate
-      pip install -e ".[dev]"
+      python -m pip install --upgrade pip
+      pip install -e .
+      pip install pytest pytest-asyncio
+
+   To build the documentation locally, also install the docs requirements:
+
+   .. code-block:: bash
+
+      pip install -r docs/requirements.txt
 
 Running Tests
 --------------
@@ -31,15 +39,18 @@ jonq uses pytest for testing. To run tests:
 
    pytest
 
+Run the full test suite before opening a pull request. If you change only
+documentation, build the Sphinx docs as well.
+
 Manual Testing
 ---------------
 
-You can also use the shell scripts in the ``jonq/json_test_files`` directory to run manual tests:
+You can also use the shell scripts in the ``tests`` directory to run manual checks:
 
 .. code-block:: bash
 
-   bash jonq/json_test_files/jonq_manual_simple_test.sh
-   bash jonq/json_test_files/jonq_manual_nested_test.sh
+   bash tests/test_simple.sh
+   bash tests/test_nested.sh
 
 Contributing Code
 ------------------
@@ -48,7 +59,7 @@ Contributing Code
 
    .. code-block:: bash
 
-      git checkout -b feature-name
+      git switch -c feature-name
 
 2. Make your changes and add tests for new features
 3. Run the test suite to make sure everything passes
@@ -85,7 +96,7 @@ If you're adding new features, please update the documentation as well. jonq use
       cd docs
       make html
 
-   The documentation will be built in ``docs/_build/html``.
+   The documentation will be built in ``docs/build/html``.
 
 Reporting Issues
 -----------------

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -204,11 +204,21 @@ Consider ``nested.json``:
        {"order_id": 103, "item": "Tablet"}
      ]
 
-- **FROM clause:**
+- **FROM clause over nested arrays:**
 
   .. code-block:: bash
 
-     jonq nested.json "select type, name from products"
+     jonq nested.json "select order_id, item, price from [].orders"
+
+  **Output:**
+
+  .. code-block:: json
+
+     [
+       {"order_id": 101, "item": "Laptop", "price": 1200},
+       {"order_id": 102, "item": "Phone", "price": 800},
+       {"order_id": 103, "item": "Tablet", "price": 500}
+     ]
 
 Multiple Input Sources
 -----------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,12 +9,12 @@ Welcome to jonq's documentation!
    :target: https://github.com/duriantaco/skylos
    :alt: Skylos Grade
 
-jonq is a Python tool for exploring, extracting, and reshaping JSON with readable jq-powered queries. It keeps familiar ``select`` / ``if`` syntax for common cases while staying focused on JSON-native terminal workflows.
+jonq is a command-line JSON tool for exploring, extracting, and reshaping payloads with readable jq-powered queries. It keeps familiar ``select`` / ``if`` syntax for common cases while staying focused on JSON-native terminal workflows.
 
 .. important::
 
-   jonq is not a database.
-   Use it to understand and shape JSON quickly, then move to an analytical tool if the problem becomes relational.
+   jonq is not a database, ETL system, or full jq replacement.
+   Use it to understand and shape JSON quickly from the shell.
 
 Key Features
 -------------
@@ -35,6 +35,7 @@ Key Features
 - **Path explorer**: run ``jonq data.json`` with no query
 - **Interactive REPL**: ``jonq -i data.json`` with tab completion and history
 - **Follow mode**: ``--follow`` to stream NDJSON line-by-line
+- **Streaming mode**: ``--stream`` for row-wise root-array queries
 - **Watch mode**: ``--watch`` to re-run on file change
 - **Multiple inputs**: local files, URLs, globs, stdin (auto-detected), NDJSON
 - **Shell completions**: ``--completions bash|zsh|fish``

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -63,3 +63,9 @@ If you want to contribute to the development of jonq, you can install from sourc
    git clone https://github.com/duriantaco/jonq.git
    cd jonq
    pip install -e .
+
+To build the documentation locally:
+
+.. code-block:: bash
+
+   pip install -r docs/requirements.txt

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -4,7 +4,7 @@ Usage
 Overview
 ---------
 
-``jonq`` is a command-line tool for exploring, extracting, and reshaping JSON with readable jq-powered queries. It keeps familiar ``select`` / ``if`` syntax for common cases, but the goal is still JSON-native terminal workflows rather than database-style analytics.
+``jonq`` is a command-line tool for exploring, extracting, and reshaping JSON with readable jq-powered queries. It is designed for JSON-native terminal workflows: inspect a payload, select the fields you need, filter rows, reshape nested arrays, and hand the result to the next shell command or script.
 
 Basic Command Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -77,7 +77,7 @@ The ``jonq`` query syntax mirrors SQL but is tailored for JSON. Here's the full 
 
 - **``<fields>``**: Fields to select (e.g., ``name``, ``age``), including aliases, expressions, or aggregations.
 - **``distinct``**: Optional keyword to return only unique rows.
-- **``from <path>``**: Optional path to query a specific part of the JSON (e.g., ``from products``).
+- **``from <path>``**: Optional path to query a specific part of the JSON (for example, ``from products`` or ``from [].orders``).
 - **``if <condition>``**: Optional filter (e.g., ``age > 30``).
 - **``group by <fields>``**: Optional grouping (e.g., ``group by city``).
 - **``having <condition>``**: Optional filter on grouped results (e.g., ``having count > 2``).
@@ -200,9 +200,9 @@ Convert between types:
 
 .. code-block:: bash
 
-   jonq data.json "select int(price) as price"        # string → integer
-   jonq data.json "select float(amount) as amount"     # string → float
-   jonq data.json "select str(code) as code"           # number → string
+   jonq data.json "select int(price) as price"        # string -> integer
+   jonq data.json "select float(amount) as amount"     # string -> float
+   jonq data.json "select str(code) as code"           # number -> string
    jonq data.json "select type(value) as t"            # get type name
 
 Date/Time Functions
@@ -212,9 +212,9 @@ Convert between epoch timestamps and ISO dates:
 
 .. code-block:: bash
 
-   jonq data.json "select todate(timestamp) as date"   # epoch → ISO date
+   jonq data.json "select todate(timestamp) as date"   # epoch -> ISO date
    jonq data.json "select date(created_at) as d"       # alias for todate
-   jonq data.json "select fromdate(iso_date) as epoch"  # ISO → epoch
+   jonq data.json "select fromdate(iso_date) as epoch"  # ISO -> epoch
 
 Null-safe: returns ``null`` instead of crashing on null input.
 
@@ -268,7 +268,7 @@ The ``FROM`` clause lets you target a specific part of the JSON structure, such 
 
   .. code-block:: bash
 
-     jonq data.json "select type, name from products"
+     jonq catalog.json "select type, name from products"
 
   Queries the ``products`` array within the JSON.
 
@@ -553,7 +553,7 @@ Launch an interactive session with tab completion and persistent history:
 
 .. code-block:: text
 
-   jonq interactive mode — querying data.json
+   jonq interactive mode - querying data.json
    Type a query, or 'quit' to exit. Tab completes field names.
 
    jonq> select name, age
@@ -660,6 +660,7 @@ For big JSON files, use streaming mode:
 
 - **Requirement:** The JSON must be an array at the root level.
 - **Benefit:** Processes data in chunks in memory, avoiding temp chunk files in the main execution path.
+- **Scope:** Streaming supports row-wise queries only. It rejects aggregations, ``group by``, ``sort``, ``distinct``, and ``limit`` because those need the full input.
 
 Tips and Tricks
 ----------------
@@ -677,7 +678,7 @@ Optimizing Performance
 
 - **Use FROM:** Narrow down the data with ``from`` to avoid processing unnecessary parts.
 - **Limit Early:** Apply ``limit`` or strict ``if`` conditions to reduce output size.
-- **Stream Large Files:** Use ``--stream`` for large root-array JSON files when you want lower-overhead chunk processing.
+- **Stream Row-wise Queries:** Use ``--stream`` for large root-array JSON files when the query can be evaluated one row at a time.
 
 Working with Arrays
 ~~~~~~~~~~~~~~~~~~~~
@@ -696,7 +697,8 @@ Known Limitations
 ------------------
 
 - **Performance with Very Large Files**: Processing JSON files exceeding 100MB may still be slow, even with streaming.
+- **Streaming Scope**: ``--stream`` is intentionally limited to row-wise queries; use normal mode for global operations.
 - **Advanced jq Features**: Some complex ``jq`` functionalities (e.g., recursive descent or custom filters) are not exposed through ``jonq``'s readable query syntax.
 - **Joins**: ``jonq`` does not support joining data across multiple JSON files.
 - **Custom Functions**: Users cannot define custom functions within queries.
-- **Window Functions**: Not supported — use an analytical query engine for analytical queries.
+- **Window Functions**: Not supported; use an analytical query engine for analytical queries.

--- a/docs/source/usage_in_python.rst
+++ b/docs/source/usage_in_python.rst
@@ -59,6 +59,10 @@ Use ``execute(...)`` when you want metadata such as the generated jq filter or r
 
    print(result.output_format)
    print(result.text)
+   print(result.compiled.jq_filter)
+
+The Python API supports ``format="json"``, ``format="jsonl"``, and
+``format="csv"``. Table and YAML rendering are CLI-only conveniences.
 
 Use ``format="jsonl"`` when you want newline-delimited JSON for downstream tools:
 
@@ -80,6 +84,36 @@ The high-level API accepts:
 - Python objects like ``dict`` and ``list``
 - Raw JSON strings
 - File paths (``str`` or ``pathlib.Path``)
+
+Validation and Limits
+---------------------
+
+File inputs are validated against the sampled JSON schema by default. Disable
+that check only when you know a query refers to fields that are absent from the
+sample:
+
+.. code-block:: python
+
+   rows = query("data.json", "select future_field", validate=False)
+
+Use ``limit=`` when you want to cap returned rows after query execution:
+
+.. code-block:: python
+
+   rows = query("data.json", "select name, age", limit=10)
+
+Streaming
+---------
+
+Set ``streaming=True`` for row-wise queries over a root-array JSON file:
+
+.. code-block:: python
+
+   rows = query("large.json", "select id, name if active = true", streaming=True)
+
+Streaming requires a filesystem path. It rejects aggregations, ``group by``,
+``sort``, ``distinct``, and ``limit`` because those operations need the full
+input.
 
 Async Usage
 -----------

--- a/jonq/generator.py
+++ b/jonq/generator.py
@@ -654,10 +654,10 @@ def generate_jq_filter(
                 expr = parse_expression(expr_txt)
                 agg_sel.append(f'"{alias}": {generate_jq_expression(expr, "group")}')
 
-        if base_selector:
-            prefix = f"[ {base_selector} ] | "
-        else:
-            prefix = "[ .[] ] | "
+        source = base_selector or ".[]"
+        if condition:
+            source = f"{source} | select({condition})"
+        prefix = f"[ {source} ] | "
 
         jq_filter = f"{prefix}map(select(. != null)) | group_by({group_key}) | map({{ {', '.join(agg_sel)} }})"
         if having:

--- a/tests/test_semantic_regressions.py
+++ b/tests/test_semantic_regressions.py
@@ -15,6 +15,21 @@ def test_count_star_respects_filter():
     assert result == {"over_25": 2}
 
 
+def test_group_by_respects_filter_before_grouping():
+    data = [
+        {"city": "New York", "age": 30},
+        {"city": "New York", "age": 20},
+        {"city": "Chicago", "age": 35},
+    ]
+
+    result = query(data, "select city, count(*) as count if age > 25 group by city")
+
+    assert result == [
+        {"city": "Chicago", "count": 1},
+        {"city": "New York", "count": 1},
+    ]
+
+
 def test_count_star_respects_from_path():
     data = {"products": [{"name": "A"}, {"name": "B"}]}
 


### PR DESCRIPTION
## Summary
- rewrite README around current CLI, output formats, streaming scope, Python API, and correct tool positioning
- replace stale top-level usage/syntax/contribution guidance and update Sphinx usage, examples, API, install, contribution, and Python docs
- fix grouped queries so if ... group by ... filters rows before aggregation, with a regression test
- make local Sphinx builds offline-friendly by enabling intersphinx only on Read the Docs or when requested

## Testing
- pytest -q (338 passed)
- pytest -q tests/test_semantic_regressions.py (12 passed)
- LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-refresh (build succeeded)
- stale-doc scan for old comparison/dev/doc references returned no matches

## Git hygiene
- branch created from current main
- staged only this PR files
- left pre-existing local changes unstaged: .DS_Store, .gitignore, docs/.DS_Store, jonq/table_utils.py, tests/test_parser_edge_cases.py, MONETIZATION_ROADMAP.md, OSS_WEDGE_PLAN.md