### PR TITLE
Support stdin issue example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ jonq users.json "select name if age > 30" --explain
 ```text
 select [distinct] <fields>
   [from <path>]
-  [if <condition>]
+  [if|where <condition>]
   [group by <fields> [having <condition>]]
   [sort <field> [asc|desc]]
   [limit N]
@@ -142,6 +142,7 @@ Examples:
 jonq users.json "select *"
 jonq users.json "select name as full_name, age"
 jonq users.json "select name if city in ('New York', 'Chicago')"
+jonq users.json "select name where age > 30"
 jonq users.json "select name if not age > 30"
 jonq users.json "select name if name like 'Al%'"
 jonq users.json "select name if age between 25 and 35"
@@ -237,6 +238,7 @@ Piped stdin:
 
 ```bash
 curl -s https://api.example.com/users | jonq "select id, name" -t
+cat data.json | jonq "select id, name where active = true"
 cat data.json | jonq - "select id, name"
 ```
 

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -2,7 +2,7 @@
 
 The general form of a jonq query is:
 ```bash
-select [distinct] <fields> [from <path>] [if <condition>] [group by <fields> [having <condition>]] [sort <field> [asc|desc]] [limit N]
+select [distinct] <fields> [from <path>] [if|where <condition>] [group by <fields> [having <condition>]] [sort <field> [asc|desc]] [limit N]
 ```
 
 jonq query syntax is for JSON extraction and reshaping. CLI behavior such as
@@ -65,12 +65,13 @@ select 'first name', "last-name", user."login-count"
 
 ## Filtering with IF
 
-Use `if` to filter results based on conditions:
+Use `if` to filter results based on conditions. `where` is accepted as an alias.
 
 ### Basic Comparisons
 
 ```bash
 select name, age if age > 30
+select name, age where age > 30
 select name, city if city = 'New York'
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -63,6 +63,7 @@ jonq users.json "select name as full_name, age as years"
 
 ```bash
 jonq users.json "select name, age if age > 30"
+jonq users.json "select name, age where age > 30"
 jonq users.json "select name if city = 'New York'"
 jonq users.json "select name if city in ('New York', 'Chicago')"
 jonq users.json "select name if not age > 30"
@@ -143,6 +144,7 @@ jonq users.json "select name, age" --format yaml   # YAML
 ```bash
 jonq data.json "select id, name"
 cat data.json | jonq - "select id, name"
+cat data.json | jonq "select id, name where active = true"
 curl -s https://api.example.com/users | jonq "select id, name"
 jonq 'logs/*.json' "select * if level = 'error'"
 jonq app.ndjson "select level, message if level = 'error'"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Welcome to jonq's documentation!
    :target: https://github.com/duriantaco/skylos
    :alt: Skylos Grade
 
-jonq is a command-line JSON tool for exploring, extracting, and reshaping payloads with readable jq-powered queries. It keeps familiar ``select`` / ``if`` syntax for common cases while staying focused on JSON-native terminal workflows.
+jonq is a command-line JSON tool for exploring, extracting, and reshaping payloads with readable jq-powered queries. It keeps familiar ``select`` / ``if`` syntax for common cases, accepts ``where`` as a filter alias, and stays focused on JSON-native terminal workflows.
 
 .. important::
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -73,12 +73,12 @@ The ``jonq`` query syntax mirrors SQL but is tailored for JSON. Here's the full 
 
 .. code-block:: sql
 
-   select [distinct] <fields> [from <path>] [if <condition>] [group by <fields> [having <condition>]] [sort <field> [asc|desc]] [limit N]
+   select [distinct] <fields> [from <path>] [if|where <condition>] [group by <fields> [having <condition>]] [sort <field> [asc|desc]] [limit N]
 
 - **``<fields>``**: Fields to select (e.g., ``name``, ``age``), including aliases, expressions, or aggregations.
 - **``distinct``**: Optional keyword to return only unique rows.
 - **``from <path>``**: Optional path to query a specific part of the JSON (for example, ``from products`` or ``from [].orders``).
-- **``if <condition>``**: Optional filter (e.g., ``age > 30``).
+- **``if <condition>`` / ``where <condition>``**: Optional filter (e.g., ``age > 30``).
 - **``group by <fields>``**: Optional grouping (e.g., ``group by city``).
 - **``having <condition>``**: Optional filter on grouped results (e.g., ``having count > 2``).
 - **``sort <field>``**: Optional sorting field (e.g., ``sort age``).
@@ -283,7 +283,7 @@ The ``FROM`` clause lets you target a specific part of the JSON structure, such 
 Filtering with Conditions
 --------------------------
 
-The ``if`` clause filters data based on conditions using comparison and logical operators.
+The ``if`` clause filters data based on conditions using comparison and logical operators. ``where`` is accepted as an alias.
 
 Basic Filtering
 ~~~~~~~~~~~~~~~~
@@ -593,6 +593,7 @@ Multiple Input Sources
 .. code-block:: bash
 
    curl -s https://api.example.com/data | jonq "select id, name"
+   cat data.json | jonq "select name, age where age > 25"
    cat data.json | jonq - "select name, age"
 
 Follow Mode

--- a/jonq/error_handler.py
+++ b/jonq/error_handler.py
@@ -235,7 +235,7 @@ def validate_query_against_schema(json_file: str, query: str) -> str | None:
             return None
 
         m = re.search(
-            r"\bselect\s+(.*?)(?:\s+(?:from|if|group|order|sort|limit)\b|$)",
+            r"\bselect\s+(.*?)(?:\s+(?:from|if|where|group|order|sort|limit)\b|$)",
             query,
             flags=re.IGNORECASE | re.DOTALL,
         )

--- a/jonq/main.py
+++ b/jonq/main.py
@@ -374,7 +374,7 @@ def _setup_repl_readline(json_file: str) -> None:
 def _build_repl_completions(json_file: str) -> list[str]:
     """Build completion list from JSON schema + keywords."""
     keywords = [
-        "select", "if", "from", "group", "by", "having", "sort", "asc", "desc",
+        "select", "if", "where", "from", "group", "by", "having", "sort", "asc", "desc",
         "limit", "distinct", "and", "or", "not", "in", "like", "between",
         "contains", "as", "case", "when", "then", "else", "end", "is", "null",
         "coalesce",
@@ -575,7 +575,7 @@ def _generate_completions(shell: str) -> str:
 _jonq_completions() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local opts="-i -f -t -s -n -o -p -w --format --table --stream --ndjson --limit --out --jq --explain --time --pretty --watch --follow --no-color --version --help --completions"
-    local keywords="select if from group by having sort asc desc limit distinct and or not in like between contains as case when then else end is null coalesce count sum avg min max upper lower length round abs ceil floor int float str type keys values trim todate fromdate date tojson fromjson"
+    local keywords="select if where from group by having sort asc desc limit distinct and or not in like between contains as case when then else end is null coalesce count sum avg min max upper lower length round abs ceil floor int float str type keys values trim todate fromdate date tojson fromjson"
 
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
@@ -607,7 +607,7 @@ _jonq() {
         '--no-color:No color'
         '--completions:Shell completions'
     )
-    keywords=(select if from group by having sort asc desc limit distinct and or not in like between contains as case when then else end is null coalesce count sum avg min max upper lower length round abs ceil floor int float str type keys values trim todate fromdate)
+    keywords=(select if where from group by having sort asc desc limit distinct and or not in like between contains as case when then else end is null coalesce count sum avg min max upper lower length round abs ceil floor int float str type keys values trim todate fromdate)
 
     if [[ "${words[2]}" == -* ]]; then
         _describe 'options' opts

--- a/jonq/query_parser.py
+++ b/jonq/query_parser.py
@@ -245,6 +245,9 @@ _SCALAR_FUNCTIONS = {
 _MULTI_ARG_FUNCTIONS = {"coalesce", "if_null"}
 _AGGREGATE_FUNCTIONS = {"count", "sum", "avg", "min", "max"}
 _ARITHMETIC_OPS = {"+", "-", "*", "/", "%", "^", "||"}
+_FILTER_CLAUSES = {"if", "where"}
+_SELECT_CLAUSES = _FILTER_CLAUSES | {"sort", "group", "having", "from", "limit"}
+_ALIAS_STOP_TOKENS = _SELECT_CLAUSES | {","}
 
 
 def parse_query(tokens: list[str]) -> tuple:
@@ -257,14 +260,7 @@ def parse_query(tokens: list[str]) -> tuple:
         i += 1
     fields = []
     expecting_field = True
-    while i < len(tokens) and tokens[i].lower() not in [
-        "if",
-        "sort",
-        "group",
-        "having",
-        "from",
-        "limit",
-    ]:
+    while i < len(tokens) and tokens[i].lower() not in _SELECT_CLAUSES:
         if tokens[i] == ",":
             if not expecting_field:
                 expecting_field = True
@@ -290,9 +286,7 @@ def parse_query(tokens: list[str]) -> tuple:
                 alias = None
                 if i < len(tokens) and tokens[i] == "as":
                     i += 1
-                    if i < len(tokens) and tokens[i].lower() not in [
-                        "if", "sort", "group", "having", ",", "from", "limit",
-                    ]:
+                    if i < len(tokens) and tokens[i].lower() not in _ALIAS_STOP_TOKENS:
                         alias = tokens[i]
                         i += 1
                     else:
@@ -332,7 +326,7 @@ def parse_query(tokens: list[str]) -> tuple:
                         if depth == 0 and (
                             token == ","
                             or token.lower()
-                            in ["if", "sort", "group", "having", "from", "limit", "as"]
+                            in (_SELECT_CLAUSES | {"as"})
                         ):
                             break
                         expr_tokens.append(token)
@@ -340,15 +334,7 @@ def parse_query(tokens: list[str]) -> tuple:
                     alias = None
                     if i < len(tokens) and tokens[i] == "as":
                         i += 1
-                        if i < len(tokens) and tokens[i].lower() not in [
-                            "if",
-                            "sort",
-                            "group",
-                            "having",
-                            ",",
-                            "from",
-                            "limit",
-                        ]:
+                        if i < len(tokens) and tokens[i].lower() not in _ALIAS_STOP_TOKENS:
                             alias = tokens[i]
                             i += 1
                         else:
@@ -361,15 +347,7 @@ def parse_query(tokens: list[str]) -> tuple:
                 alias = None
                 if i < len(tokens) and tokens[i] == "as":
                     i += 1
-                    if i < len(tokens) and tokens[i].lower() not in [
-                        "if",
-                        "sort",
-                        "group",
-                        "having",
-                        ",",
-                        "from",
-                        "limit",
-                    ]:
+                    if i < len(tokens) and tokens[i].lower() not in _ALIAS_STOP_TOKENS:
                         alias = tokens[i]
                         i += 1
                     else:
@@ -417,7 +395,7 @@ def parse_query(tokens: list[str]) -> tuple:
                     elif depth == 0 and (
                         token in [",", "as"]
                         or token.lower()
-                        in ["if", "sort", "group", "having", "from", "limit"]
+                        in _SELECT_CLAUSES
                     ):
                         break
                     field_tokens.append(token)
@@ -433,15 +411,7 @@ def parse_query(tokens: list[str]) -> tuple:
                 alias = None
                 if i < len(tokens) and tokens[i] == "as":
                     i += 1
-                    if i < len(tokens) and tokens[i].lower() not in [
-                        "if",
-                        "sort",
-                        "group",
-                        "having",
-                        ",",
-                        "from",
-                        "limit",
-                    ]:
+                    if i < len(tokens) and tokens[i].lower() not in _ALIAS_STOP_TOKENS:
                         alias = tokens[i]
                         i += 1
                     else:
@@ -469,19 +439,15 @@ def parse_query(tokens: list[str]) -> tuple:
     from_path = None
     if i < len(tokens) and tokens[i].lower() == "from":
         i += 1
-        if i < len(tokens) and tokens[i].lower() not in [
-            "if",
-            "sort",
-            "group",
-            "having",
-            "limit",
-        ]:
+        if i < len(tokens) and tokens[i].lower() not in (
+            _FILTER_CLAUSES | {"sort", "group", "having", "limit"}
+        ):
             from_path = tokens[i]
             i += 1
         else:
             raise ValueError("Expected path after 'from'")
     condition = None
-    if i < len(tokens) and tokens[i].lower() == "if":
+    if i < len(tokens) and tokens[i].lower() in _FILTER_CLAUSES:
         i += 1
         condition_tokens = []
         while i < len(tokens) and tokens[i].lower() not in [

--- a/tests/jq_main_test.py
+++ b/tests/jq_main_test.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 from unittest.mock import patch, AsyncMock
 from jonq.main import main
@@ -20,6 +22,32 @@ def test_main_with_from_clause(tmp_path, capsys):
         main()
     captured = capsys.readouterr()
     assert "Software" in captured.out
+
+
+def test_main_reads_piped_stdin_without_dash(capsys):
+    stdin = io.StringIO(
+        '[{"name":"Alice","age":30},{"name":"Bob","age":25},{"name":"Charlie","age":35}]'
+    )
+
+    with patch("sys.argv", ["jonq", "select name where age > 25"]):
+        with patch("sys.stdin", stdin):
+            main()
+
+    captured = capsys.readouterr()
+    assert "Alice" in captured.out
+    assert "Charlie" in captured.out
+    assert "Bob" not in captured.out
+
+
+def test_main_reads_piped_stdin_with_dash(capsys):
+    stdin = io.StringIO('[{"name":"Alice","age":30}]')
+
+    with patch("sys.argv", ["jonq", "-", "select name"]):
+        with patch("sys.stdin", stdin):
+            main()
+
+    captured = capsys.readouterr()
+    assert "Alice" in captured.out
 
 
 def test_main_file_not_found(capsys):

--- a/tests/test_semantic_regressions.py
+++ b/tests/test_semantic_regressions.py
@@ -30,6 +30,12 @@ def test_group_by_respects_filter_before_grouping():
     ]
 
 
+def test_where_alias_matches_if_filter():
+    data = [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 20}]
+
+    assert query(data, "select name where age > 25") == [{"name": "Alice"}]
+
+
 def test_count_star_respects_from_path():
     data = {"products": [{"name": "A"}, {"name": "B"}]}
 


### PR DESCRIPTION
## Summary
- add regression coverage for reading piped JSON with and without explicit `-`
- support `where` as an alias for `if`, matching the issue #1 example syntax
- update schema validation, completions, README, USAGE, SYNTAX, and Sphinx usage docs for the alias

Closes #1

## Testing
- `cat tests/json_test_files/simple.json | python -m jonq "select * where city = 'Chicago'"`
- `pytest -q tests/jq_main_test.py tests/test_semantic_regressions.py tests/jq_query_parser_test.py tests/test_new_features.py` (96 passed)
- `pytest -q` (341 passed)
- `LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-issue-1` (build succeeded)

## Git hygiene
- branch created from current `main`
- focused parser/CLI/docs/test changes only
- working tree clean after commit