### PR TITLE
Add release automation and pre-commit hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*
+
+      - name: Smoke test wheel
+        run: |
+          python -m pip install dist/*.whl
+          jonq --version
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pytest_cache
+.ruff_cache
 __pycache__
 *.pyc
 *.pyo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check --fix --force-exclude
+        language: system
+        types_or: [python, pyi]
+        stages: [pre-commit]
+
+      - id: compile-jonq
+        name: compile jonq package
+        entry: python -m compileall -q jonq
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: pytest-smoke
+        name: pytest smoke
+        entry: pytest -q tests/test_semantic_regressions.py tests/jq_main_test.py
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -6,8 +6,8 @@ Thanks for your interest in helping with jonq! Here's how you can contribute:
 
 1. Fork the repo
 2. Clone your fork: `git clone https://github.com/duriantaco/jonq.git`
-3. Install for development: `pip install -e .`
-4. Install test dependencies: `pip install pytest pytest-asyncio`
+3. Install for development: `pip install -e ".[dev]"`
+4. Install hooks: `pre-commit install --install-hooks`
 5. Install docs dependencies when editing docs: `pip install -r docs/requirements.txt`
 
 ## How to Contribute
@@ -27,6 +27,7 @@ Thanks for your interest in helping with jonq! Here's how you can contribute:
 7. Open a pull request
 
 ### Code Style
+- Run `pre-commit run --all-files` before pushing
 - Follow PEP 8 basics
 - Include docstrings for functions and classes
 
@@ -37,6 +38,17 @@ Run `pytest` before submitting your changes.
 Keep `README.md`, `USAGE.md`, `SYNTAX.md`, and the Sphinx docs in `docs/source/`
 in sync when changing CLI behavior, query syntax, output formats, or the Python
 API.
+
+## Releases
+Maintainers publish from GitHub Releases:
+
+1. Update `pyproject.toml`, `jonq/constants.py`, and `CHANGELOG.md`
+2. Open and merge the release prep PR
+3. Create a GitHub Release for the version tag
+4. The release workflow builds the package and publishes it to PyPI
+
+PyPI publishing uses trusted publishing, so the PyPI project must allow this
+repository and the `pypi` GitHub environment.
 
 ## Need Help?
 Open an issue with your question!

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -21,8 +21,8 @@ Setting Up Development Environment
       python -m venv venv
       source venv/bin/activate  # On Windows: venv\Scripts\activate
       python -m pip install --upgrade pip
-      pip install -e .
-      pip install pytest pytest-asyncio
+      pip install -e ".[dev]"
+      pre-commit install --install-hooks
 
    To build the documentation locally, also install the docs requirements:
 
@@ -41,6 +41,16 @@ jonq uses pytest for testing. To run tests:
 
 Run the full test suite before opening a pull request. If you change only
 documentation, build the Sphinx docs as well.
+
+Pre-Commit Hooks
+-----------------
+
+The repository includes local pre-commit hooks for Ruff, package compilation,
+and a focused pre-push pytest smoke suite.
+
+.. code-block:: bash
+
+   pre-commit run --all-files
 
 Manual Testing
 ---------------
@@ -102,3 +112,11 @@ Reporting Issues
 -----------------
 
 If you find a bug or have a suggestion for improvement, please create an issue on the GitHub repository.
+
+Releases
+---------
+
+Maintainers publish from GitHub Releases. Before creating a release, update
+``pyproject.toml``, ``jonq/constants.py``, and ``CHANGELOG.md`` in a release
+prep pull request. Publishing uses PyPI trusted publishing from the ``pypi``
+GitHub environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,27 @@ jonq = "jonq.main:entrypoint"
 packages = ["jonq"]
 
 [project.optional-dependencies]
+dev = [
+    "build",
+    "pre-commit",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "ruff",
+    "twine",
+]
 docs = [
     "sphinx",
     "sphinx-rtd-theme",
     "sphinx-autodoc-typehints",
     "myst-parser",
 ]
+
+[tool.ruff]
+target-version = "py39"
+extend-exclude = [
+    "docs/build",
+]
+
+[tool.ruff.lint]
+select = ["E9", "F"]

--- a/tests/jq_filter_test.py
+++ b/tests/jq_filter_test.py
@@ -1,4 +1,3 @@
-import re
 import pytest
 from jonq.jq_filter import generate_jq_filter
 

--- a/tests/jq_having_test.py
+++ b/tests/jq_having_test.py
@@ -1,4 +1,3 @@
-from jonq.tokenizer import tokenize
 from jonq.query_parser import parse_query, tokenize_query
 
 def print_parsed_query(query):

--- a/tests/jq_stream_utils.py
+++ b/tests/jq_stream_utils.py
@@ -11,7 +11,6 @@ from jonq.stream_utils import (
     process_json_streaming,
     process_json_streaming_async,
 )
-from jonq.executor import run_jq, run_jq_streaming, run_jq_async, run_jq_streaming_async
 
 class TestJsonOptimization:
     @pytest.fixture
@@ -60,7 +59,7 @@ class TestJsonOptimization:
             stdlib_json.loads(stdlib_serialized)
         stdlib_loads_time = time.time() - start
         
-        print(f"\nJSON Performance Results:")
+        print("\nJSON Performance Results:")
         print(f"  Serialization   - Custom: {custom_dumps_time:.4f}s, Stdlib: {stdlib_dumps_time:.4f}s")
         print(f"  Deserialization - Custom: {custom_loads_time:.4f}s, Stdlib: {stdlib_loads_time:.4f}s")
         

--- a/tests/jq_tokenizer.py
+++ b/tests/jq_tokenizer.py
@@ -89,14 +89,14 @@ def test_special_cases():
 def test_error_cases():
     query = "select name if name = 'John"
     try:
-        tokens = tokenize(query)
+        tokenize(query)
         print("❌ Unbalanced quotes: FAILED - Should have raised an exception")
     except Exception as e:
         print(f"✅ Unbalanced quotes: PASSED - Got expected exception: {str(e)}")
     
     query = "select name; drop table users;"
     try:
-        tokens = tokenize(query)
+        tokenize(query)
         print("❌ Invalid character: FAILED - Should have raised an exception")
     except Exception as e:
         print(f"✅ Invalid character: PASSED - Got expected exception: {str(e)}")

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,4 +1,3 @@
-import pytest
 import json
 import os
 import tempfile


### PR DESCRIPTION
## Summary
- add a release workflow that builds distributions, checks them with twine, smoke-tests the wheel, and publishes to PyPI when a GitHub Release is published
- add local pre-commit hooks for Ruff, package compilation, and a pre-push pytest smoke suite
- add a dev extra for release/lint/test tooling and document the hook and release flow
- clean existing Ruff E9/F findings in tests so the hook starts green

## Testing
- `uvx ruff check --force-exclude jonq tests`
- `python -m compileall -q jonq`
- `pytest -q tests/test_semantic_regressions.py tests/jq_main_test.py` (23 passed)
- `pytest -q` (341 passed)
- `LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-release-precommit` (build succeeded)
- `python -m build` (built wheel and sdist)
- `python -m twine check dist/*` (passed)
- `python -m pre_commit run --all-files` (passed)
- `python -m pre_commit run --hook-stage pre-push --all-files` (passed)

## Release note
PyPI publishing uses trusted publishing. Before the first automated publish, configure the PyPI project to trust this repository and the `pypi` GitHub environment.

## Git hygiene
- branch created from current `main`
- squash merge expected
- working tree clean after commit