### PR TITLE
Add raw scalar output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Raw scalar output**: `-r`, `--raw`, and `--raw-output` print selected scalar values without JSON quotes for shell pipelines.
+
 ## [v0.3.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Instead of raw jq:
 jq '.[] | select(.age > 30) | {name, age}' users.json
 ```
 
-jonq compiles your query to jq and executes it with a reusable jq worker. It is useful when you need to understand an unfamiliar JSON payload, extract fields, filter rows, flatten nested arrays, or turn JSON into table, CSV, JSONL, or YAML output.
+jonq compiles your query to jq and executes it with a reusable jq worker. It is useful when you need to understand an unfamiliar JSON payload, extract fields, filter rows, flatten nested arrays, or turn JSON into table, CSV, JSONL, YAML, or raw scalar output.
 
 > jonq is not a database, ETL framework, or analytics engine. It is a JSON exploration and shaping tool for terminal workflows.
 
@@ -41,7 +41,7 @@ Use jonq when you need to:
 - select and rename fields without remembering jq object syntax
 - filter JSON with readable conditions
 - query nested objects and arrays
-- produce table, CSV, JSONL, YAML, or compact JSON output
+- produce table, CSV, JSONL, YAML, raw scalar, or compact JSON output
 - run the same query in shell scripts, CI, or Python code
 - follow NDJSON logs line-by-line
 
@@ -99,6 +99,12 @@ Filter rows:
 
 ```bash
 jonq users.json "select name, age if age > 30"
+```
+
+Print raw values for shell pipelines:
+
+```bash
+jonq users.json "select name" -r
 ```
 
 Render a table:
@@ -224,6 +230,12 @@ YAML:
 
 ```bash
 jonq users.json "select name, age" --format yaml
+```
+
+Raw scalar values:
+
+```bash
+jonq users.json "select name" -r
 ```
 
 ## Input Sources
@@ -361,6 +373,7 @@ Async helpers are also available: `query_async(...)` and `execute_async(...)`.
 |--------|-------------|
 | `-f, --format {json,jsonl,csv,table,yaml}` | Output format |
 | `-t, --table` | Shorthand for `--format table` |
+| `-r, --raw, --raw-output` | Print scalar values without JSON quoting |
 | `-s, --stream` | Chunk-safe streaming for root-array JSON |
 | `--ndjson` | Force NDJSON mode |
 | `--follow` | Process NDJSON from stdin line-by-line |

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,6 +137,7 @@ jonq users.json "select name, age" -t              # table
 jonq users.json "select name, age" --format csv    # CSV
 jonq users.json "select name, age" --format jsonl  # JSONL
 jonq users.json "select name, age" --format yaml   # YAML
+jonq users.json "select name" -r                   # raw values
 ```
 
 ## Input Sources

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,7 +57,7 @@ The entry point for the jonq command-line tool.
 
 .. code-block:: bash
 
-   jonq <source> "<query>" [--format json|jsonl|csv|table|yaml] [--stream] [--watch] [--jq] [--explain] [--pretty] [--no-color] [--ndjson] [--limit N] [--out PATH] [--version]
+   jonq <source> "<query>" [--format json|jsonl|csv|table|yaml] [--raw] [--stream] [--watch] [--jq] [--explain] [--pretty] [--no-color] [--ndjson] [--limit N] [--out PATH] [--version]
 
 Query Parser (jonq.query_parser)
 --------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ Key Features
 - **GROUP BY** with **HAVING**
 - **Table output**: ``-t`` for aligned terminal tables
 - **JSONL / YAML output**: ``--format jsonl`` and ``--format yaml``
+- **Raw scalar output**: ``-r`` for unquoted values in shell pipelines
 - **Path explorer**: run ``jonq data.json`` with no query
 - **Interactive REPL**: ``jonq -i data.json`` with tab completion and history
 - **Follow mode**: ``--follow`` to stream NDJSON line-by-line

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -27,6 +27,8 @@ Run ``jonq`` with the following syntax:
      - Output format: ``json`` (default), ``jsonl``, ``csv``, ``table``, ``yaml``
    * - ``-t, --table``
      - Shorthand for ``--format table``
+   * - ``-r, --raw, --raw-output``
+     - Print scalar values without JSON quoting
    * - ``--stream, -s``
      - Process row-wise root-array queries in memory-friendly chunks
    * - ``--ndjson``
@@ -530,6 +532,15 @@ Choose how results are displayed:
       jonq data.json "select name, age" --format yaml
 
   Uses ``pyyaml`` if installed, built-in fallback otherwise.
+
+- **Raw scalar values:**
+
+  .. code-block:: bash
+
+      jonq data.json "select name" -r
+
+  Prints one selected value per line, without JSON string quotes. Multi-field
+  rows remain compact JSON objects, one per line.
 
 Path Explorer
 --------------

--- a/jonq/main.py
+++ b/jonq/main.py
@@ -518,6 +518,32 @@ def _json_to_jsonl(json_text: str) -> str:
     return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
 
 
+def _json_to_raw(json_text: str) -> str:
+    try:
+        data = json.loads(json_text)
+    except (json.JSONDecodeError, TypeError):
+        return json_text
+
+    if isinstance(data, list):
+        return "\n".join(_raw_line(item) for item in data)
+    return _raw_line(data)
+
+
+def _raw_line(value) -> str:
+    if isinstance(value, dict) and len(value) == 1:
+        value = next(iter(value.values()))
+
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    return str(value)
+
+
 def _json_to_yaml_simple(json_text: str) -> str:
     try:
         data = json.loads(json_text)
@@ -574,7 +600,7 @@ def _generate_completions(shell: str) -> str:
 # Add to ~/.bashrc: eval "$(jonq --completions bash)"
 _jonq_completions() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local opts="-i -f -t -s -n -o -p -w --format --table --stream --ndjson --limit --out --jq --explain --time --pretty --watch --follow --no-color --version --help --completions"
+    local opts="-i -f -t -r -s -n -o -p -w --format --table --raw --raw-output --stream --ndjson --limit --out --jq --explain --time --pretty --watch --follow --no-color --version --help --completions"
     local keywords="select if where from group by having sort asc desc limit distinct and or not in like between contains as case when then else end is null coalesce count sum avg min max upper lower length round abs ceil floor int float str type keys values trim todate fromdate date tojson fromjson"
 
     if [[ "${cur}" == -* ]]; then
@@ -595,12 +621,15 @@ _jonq() {
         '-i:Interactive mode'
         '-f:Output format'
         '-t:Table output'
+        '-r:Raw scalar output'
         '-s:Streaming mode'
         '-n:Limit rows'
         '-o:Output file'
         '-p:Pretty print'
         '-w:Watch mode'
         '--follow:Follow stdin'
+        '--raw:Raw scalar output'
+        '--raw-output:Raw scalar output'
         '--jq:Show jq filter'
         '--explain:Explain query'
         '--time:Show timing'
@@ -624,6 +653,8 @@ compdef _jonq jonq'''
 complete -c jonq -s i -l interactive -d 'Interactive mode' -r -F
 complete -c jonq -s f -l format -d 'Output format' -x -a 'json jsonl csv table yaml'
 complete -c jonq -s t -l table -d 'Table output'
+complete -c jonq -s r -l raw -d 'Raw scalar output'
+complete -c jonq -l raw-output -d 'Raw scalar output'
 complete -c jonq -s s -l stream -d 'Streaming mode'
 complete -c jonq -s n -l limit -d 'Limit rows' -x
 complete -c jonq -s o -l out -d 'Output file' -r -F
@@ -678,6 +709,8 @@ async def _follow_stdin(query: str, options: dict) -> None:
                         result = _json_to_yaml(result)
                     elif options["format"] == "jsonl":
                         result = _json_to_jsonl(result)
+                    elif options.get("raw_output"):
+                        result = _json_to_raw(result)
                     elif is_tty and not options.get("no_color"):
                         result = _pretty_json_string(result)
                         result = _colorize_json(result)
@@ -727,6 +760,8 @@ async def _run_query(json_file: str, query: str, options: dict) -> str | None:
         out_text = json_to_table(out_text, color=use_color)
     elif options["format"] == "yaml":
         out_text = _json_to_yaml(out_text)
+    elif options.get("raw_output"):
+        out_text = _json_to_raw(out_text)
     elif options["format"] == "json":
         if options.get("pretty") or (is_tty and not options.get("no_color")):
             out_text = _pretty_json_string(out_text)
@@ -792,6 +827,9 @@ async def _amain(argv: list[str] | None = None):
         parser.error("--interactive does not accept positional source/query arguments.")
 
     options = _options_from_args(args)
+
+    if options.get("raw_output") and options["format"] != "json":
+        parser.error("--raw/--raw-output can only be used with JSON output.")
 
     if args.interactive:
         json_file = args.interactive
@@ -948,6 +986,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Shorthand for --format table",
     )
     parser.add_argument(
+        "-r",
+        "--raw",
+        "--raw-output",
+        dest="raw_output",
+        action="store_true",
+        help="Print scalar values without JSON quoting (one value per line)",
+    )
+    parser.add_argument(
         "-s",
         "--stream",
         dest="streaming",
@@ -1033,6 +1079,7 @@ def _options_from_args(args: argparse.Namespace) -> dict:
         "explain": getattr(args, "explain", False),
         "show_time": getattr(args, "show_time", False),
         "pretty": args.pretty,
+        "raw_output": getattr(args, "raw_output", False),
         "watch": args.watch,
         "no_color": args.no_color,
         "follow": getattr(args, "follow", False),

--- a/tests/jq_main_test.py
+++ b/tests/jq_main_test.py
@@ -50,6 +50,47 @@ def test_main_reads_piped_stdin_with_dash(capsys):
     assert "Alice" in captured.out
 
 
+def test_main_raw_output_prints_single_field_values(tmp_path, capsys):
+    json_file = tmp_path / "test.json"
+    json_file.write_text(
+        '[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]'
+    )
+
+    with patch("sys.argv", ["jonq", str(json_file), "select name", "-r"]):
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.out == "Alice\nBob\n"
+
+
+def test_main_raw_output_keeps_multi_field_rows_scriptable(tmp_path, capsys):
+    json_file = tmp_path / "test.json"
+    json_file.write_text(
+        '[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]'
+    )
+
+    with patch("sys.argv", ["jonq", str(json_file), "select name, age", "--raw"]):
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.out == (
+        '{"name":"Alice","age":30}\n{"name":"Bob","age":25}\n'
+    )
+
+
+def test_main_raw_output_rejects_non_json_format(tmp_path, capsys):
+    json_file = tmp_path / "test.json"
+    json_file.write_text('[{"name": "Alice"}]')
+
+    with patch("sys.argv", ["jonq", str(json_file), "select name", "-r", "-t"]):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 2
+    assert "--raw/--raw-output" in captured.err
+
+
 def test_main_file_not_found(capsys):
     with patch("sys.argv", ["jonq", "nonexistent.json", "select name"]):
         with pytest.raises(SystemExit) as excinfo:

--- a/tests/test_main_edge_cases.py
+++ b/tests/test_main_edge_cases.py
@@ -6,6 +6,7 @@ from jonq.main import (
     _concat_glob,
     _type_label,
     _preview_value,
+    _json_to_raw,
     _json_to_yaml,
     _json_to_yaml_simple,
     _yaml_scalar,
@@ -203,6 +204,26 @@ class TestJsonToYamlSimple:
     def test_invalid_json(self):
         result = _json_to_yaml_simple("not json")
         assert result == "not json"
+
+
+class TestJsonToRaw:
+    def test_scalar_values_from_single_field_rows(self):
+        result = _json_to_raw('[{"name":"Alice"},{"name":"Bob"}]')
+
+        assert result == "Alice\nBob"
+
+    def test_multi_field_rows_fall_back_to_compact_jsonl(self):
+        result = _json_to_raw('[{"name":"Alice","age":30},{"name":"Bob","age":25}]')
+
+        assert result == '{"name":"Alice","age":30}\n{"name":"Bob","age":25}'
+
+    def test_json_scalars_match_shell_friendly_values(self):
+        result = _json_to_raw('["Alice",42,true,false,null]')
+
+        assert result == "Alice\n42\ntrue\nfalse\nnull"
+
+    def test_invalid_json_is_unchanged(self):
+        assert _json_to_raw("not json") == "not json"
 
 
 class TestJsonToYaml:


### PR DESCRIPTION
## Summary
- Add jq-style raw scalar output with -r, --raw, and --raw-output
- Print single-field query results as plain values, one per line
- Keep multi-field rows scriptable by rendering compact JSON objects per line
- Update README, usage docs, API docs, completions, and changelog

## Verification
- pytest -q
- uvx ruff check --force-exclude jonq tests
- python -m compileall -q jonq
- LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-raw-output
- python -m pre_commit run --all-files
- python -m pre_commit run --hook-stage pre-push --all-files
- python -m jonq tests/json_test_files/simple.json "select name" -r
- python -m jonq tests/json_test_files/simple.json "select name, age" -r