### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [v0.3.1] - 2026-04-29
 
 ### Added
 - **Raw scalar output**: `-r`, `--raw`, and `--raw-output` print selected scalar values without JSON quotes for shell pipelines.

--- a/jonq/constants.py
+++ b/jonq/constants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 USER_AGENT = f"jonq/{VERSION}"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jonq"
-version = "0.3.0"
+version = "0.3.1"
 description = "Readable jq for JSON extraction and exploration"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump package version from 0.3.0 to 0.3.1
- Move the raw scalar output changelog entry into the v0.3.1 release section

## Release notes
- Adds -r, --raw, and --raw-output for unquoted scalar output in shell pipelines
- Example: jonq users.json "select name" -r

## Verification
- pytest -q
- uvx ruff check --force-exclude jonq tests
- python -m compileall -q jonq
- python -m build
- python -m twine check dist/*
- python -m jonq --version
- python -m pre_commit run --all-files
- python -m pre_commit run --hook-stage pre-push --all-files