### PR TITLE
Improve Smart Inspect mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Smart Inspect mode**: running `jonq data.json` now shows root shape, readable field types, sample values, and suggested queries without adding new CLI flags.
+
 ## [v0.3.1] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ tail -f app.ndjson | jonq --follow "select level, message if level = 'error'" -t
 
 ## Inspect Before Querying
 
-Run jonq with no query to inspect paths, inferred types, sample values, and a suggested query:
+Run jonq with no query to inspect shape, fields, sample values, and suggested queries:
 
 ```bash
 jonq data.json
@@ -289,13 +289,14 @@ jonq data.json
 Example output:
 
 ```text
-data.json  (array, sampled 3 items)
+data.json
+Root: array of objects (sampled 3 items)
 
-Paths:
-  id    int  1
-  name  str  "Alice"
-  age   int  30
-  city  str  "New York"
+Fields:
+  id    number  sample: 1
+  name  string  sample: "Alice"
+  age   number  sample: 30
+  city  string  sample: "New York"
 
 Sample:
   {
@@ -305,7 +306,10 @@ Sample:
     "city": "New York"
   }
 
-Tip: jonq data.json "select id, name"
+Suggested queries:
+  jonq data.json "select id, name, city" -t
+  jonq data.json "select name" -r
+  jonq data.json "select city, count(*) as count group by city" -t
 ```
 
 ## Streaming and Watch Modes

--- a/USAGE.md
+++ b/USAGE.md
@@ -45,7 +45,7 @@ JSON
 
 ## Inspect JSON First
 
-Run jonq with no query to see paths, types, sample values, and a suggested query:
+Run jonq with no query to see the root shape, fields, sample values, and suggested queries:
 
 ```bash
 jonq users.json

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ Key Features
 - **Table output**: ``-t`` for aligned terminal tables
 - **JSONL / YAML output**: ``--format jsonl`` and ``--format yaml``
 - **Raw scalar output**: ``-r`` for unquoted values in shell pipelines
-- **Path explorer**: run ``jonq data.json`` with no query
+- **Smart Inspect**: run ``jonq data.json`` to see fields, samples, and suggested queries
 - **Interactive REPL**: ``jonq -i data.json`` with tab completion and history
 - **Follow mode**: ``--follow`` to stream NDJSON line-by-line
 - **Streaming mode**: ``--stream`` for row-wise root-array queries

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -542,16 +542,16 @@ Choose how results are displayed:
   Prints one selected value per line, without JSON string quotes. Multi-field
   rows remain compact JSON objects, one per line.
 
-Path Explorer
+Smart Inspect
 --------------
 
-Run ``jonq`` with just a file (no query) to inspect nested JSON paths before writing a query:
+Run ``jonq`` with just a file (no query) to inspect the root shape, fields, sample values, and suggested queries before writing a query:
 
 .. code-block:: bash
 
    jonq data.json
 
-This shows file info, nested paths with inferred types, and a truncated sample object.
+This shows root type information, nested fields with inferred types, a truncated sample object, and copy-paste query suggestions based on the fields found in the data.
 
 Interactive REPL
 -----------------
@@ -681,7 +681,7 @@ Debugging Queries
 ~~~~~~~~~~~~~~~~~~
 
 - **Test Small:** Start with a simple ``select *`` to verify the JSON structure.
-- **Use the Path Explorer:** Run ``jonq data.json`` (no query) to inspect nested paths and types.
+- **Use Smart Inspect:** Run ``jonq data.json`` (no query) to inspect nested fields, types, samples, and suggested queries.
 - **See the jq filter:** Use ``--jq`` to see the generated jq filter, or ``--explain`` for a full breakdown.
 - **Quote Strings:** Always quote string literals in conditions (e.g., ``'New York'``).
 

--- a/jonq/main.py
+++ b/jonq/main.py
@@ -9,6 +9,7 @@ import logging
 import asyncio
 import time
 import subprocess
+import shlex
 from collections import OrderedDict
 
 from jonq.api import compile_query, execute_async
@@ -267,31 +268,190 @@ def _collect_schema_paths(sample):
     return paths
 
 
-def _print_schema(json_file: str) -> None:
+def _display_schema_type(type_label: str) -> str:
+    if type_label.startswith("array[") and type_label.endswith("]"):
+        inner = type_label[len("array[") : -1]
+        if inner == "empty":
+            return "array[empty]"
+        parts = [part.strip() for part in inner.split("|")]
+        return "array[" + " | ".join(_display_schema_type(part) for part in parts) + "]"
+    if type_label.startswith("object"):
+        return "object"
+    return {
+        "str": "string",
+        "int": "number",
+        "float": "number",
+        "bool": "boolean",
+    }.get(type_label, type_label)
+
+
+def _format_schema_types(types: list[str]) -> str:
+    labels = []
+    for type_label in types:
+        display = _display_schema_type(type_label)
+        if display not in labels:
+            labels.append(display)
+    return " | ".join(labels)
+
+
+def _root_summary(root_kind: str, sample) -> str:
+    if root_kind == "empty":
+        return "empty"
+    if root_kind == "scalar":
+        return f"scalar {_display_schema_type(_type_label(sample))}"
+    if root_kind == "object":
+        return "object"
+    if root_kind == "array":
+        sample_count = len(sample)
+        if not sample:
+            item_summary = "empty"
+        else:
+            item_types = []
+            for item in sample:
+                item_type = _display_schema_type(_type_label(item))
+                if item_type not in item_types:
+                    item_types.append(item_type)
+            item_summary = " | ".join(item_types)
+            if item_summary == "object":
+                item_summary = "objects"
+        suffix = f"sampled {sample_count} item{'s' if sample_count != 1 else ''}"
+        return f"array of {item_summary} ({suffix})"
+    return root_kind
+
+
+def _is_scalar_schema_info(info) -> bool:
+    return all(
+        not type_label.startswith("object") and not type_label.startswith("array[")
+        for type_label in info["types"]
+    )
+
+
+def _path_leaf(path: str) -> str:
+    return path.replace("[]", "").split(".")[-1].lower()
+
+
+def _pick_select_fields(paths: list[str], limit: int = 3) -> list[str]:
+    preferred_names = (
+        "id",
+        "name",
+        "title",
+        "email",
+        "status",
+        "type",
+        "level",
+        "message",
+        "city",
+    )
+    preferred = [path for path in paths if _path_leaf(path) in preferred_names]
+    selected = []
+    for path in preferred + paths:
+        if path not in selected:
+            selected.append(path)
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def _format_suggested_command(source: str, query: str, *options: str) -> str:
+    query_arg = f'"{query}"' if '"' not in query else shlex.quote(query)
+    parts = ["jonq", shlex.quote(source), query_arg, *options]
+    return " ".join(parts)
+
+
+def _suggest_queries(source: str, path_map) -> list[str]:
+    flat_scalars = [
+        path
+        for path, info in path_map.items()
+        if "[]" not in path and _is_scalar_schema_info(info)
+    ]
+    if not flat_scalars:
+        return []
+
+    suggestions = []
+    selected = _pick_select_fields(flat_scalars)
+    if selected:
+        suggestions.append(
+            _format_suggested_command(source, f"select {', '.join(selected)}", "-t")
+        )
+
+    raw_candidates = []
+    for leaf in ("name", "title", "email", "message", "id"):
+        raw_candidates.extend(path for path in flat_scalars if _path_leaf(path) == leaf)
+    raw_field = raw_candidates[0] if raw_candidates else flat_scalars[0]
+    suggestions.append(_format_suggested_command(source, f"select {raw_field}", "-r"))
+
+    bool_fields = [
+        path
+        for path in flat_scalars
+        if any(type_label == "bool" for type_label in path_map[path]["types"])
+    ]
+    if bool_fields and selected:
+        suggestions.append(
+            _format_suggested_command(
+                source,
+                f"select {', '.join(selected)} where {bool_fields[0]} = true",
+                "-t",
+            )
+        )
+    else:
+        groupable_names = (
+            "status",
+            "type",
+            "level",
+            "city",
+            "country",
+            "category",
+            "kind",
+            "state",
+            "plan",
+        )
+        group_fields = [
+            path
+            for path in flat_scalars
+            if _path_leaf(path) in groupable_names
+            and any(type_label == "str" for type_label in path_map[path]["types"])
+        ]
+        if group_fields:
+            group_field = group_fields[0]
+            suggestions.append(
+                _format_suggested_command(
+                    source,
+                    f"select {group_field}, count(*) as count group by {group_field}",
+                    "-t",
+                )
+            )
+
+    deduped = []
+    for suggestion in suggestions:
+        if suggestion not in deduped:
+            deduped.append(suggestion)
+    return deduped[:3]
+
+
+def _print_schema(json_file: str, display_name: str | None = None) -> None:
     is_tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
     c = _Colors(is_tty)
+    display_name = display_name or json_file
 
     root_kind, sample = _sample_json_for_schema(json_file)
 
     if root_kind == "empty":
-        print(f"{c.BOLD}{json_file}{c.NC}  {c.DIM}(empty){c.NC}")
+        print(f"{c.BOLD}{display_name}{c.NC}")
+        print(f"{c.BOLD}Root:{c.NC} {c.DIM}{_root_summary(root_kind, sample)}{c.NC}")
         return
 
     if root_kind == "scalar":
-        print(
-            f"{c.BOLD}{json_file}{c.NC}  {c.DIM}(scalar: {_type_label(sample)}){c.NC}"
-        )
+        print(f"{c.BOLD}{display_name}{c.NC}")
+        print(f"{c.BOLD}Root:{c.NC} {c.DIM}{_root_summary(root_kind, sample)}{c.NC}")
         print(f"  {sample}")
         return
 
+    print(f"{c.BOLD}{display_name}{c.NC}")
+    print(f"{c.BOLD}Root:{c.NC} {c.DIM}{_root_summary(root_kind, sample)}{c.NC}")
+
     if root_kind == "array":
-        sample_count = len(sample)
-        print(
-            f"{c.BOLD}{json_file}{c.NC}  {c.DIM}(array, sampled {sample_count} item{'s' if sample_count != 1 else ''}){c.NC}"
-        )
         sample_for_display = sample[0] if sample else []
     else:
-        print(f"{c.BOLD}{json_file}{c.NC}  {c.DIM}(object){c.NC}")
         sample_for_display = sample
 
     path_map = _collect_schema_paths(sample)
@@ -299,23 +459,32 @@ def _print_schema(json_file: str) -> None:
         print("  No object-like paths found in sample.")
         return
 
-    print(f"\n{c.BOLD}Paths:{c.NC}")
+    print(f"\n{c.BOLD}Fields:{c.NC}")
     max_key = max((len(k) for k in path_map), default=0)
+    max_type = max(
+        (len(_format_schema_types(info["types"])) for info in path_map.values()),
+        default=0,
+    )
     for key, info in path_map.items():
-        type_label = " | ".join(info["types"])
-        preview = f"  {c.DIM}{info['preview']}{c.NC}" if info["preview"] else ""
+        type_label = _format_schema_types(info["types"])
+        preview = f"  {c.DIM}sample: {info['preview']}{c.NC}" if info["preview"] else ""
         print(
-            f"  {c.GREEN}{key:<{max_key}}{c.NC}  {c.YELLOW}{type_label}{c.NC}{preview}"
+            f"  {c.GREEN}{key:<{max_key}}{c.NC}  {c.YELLOW}{type_label:<{max_type}}{c.NC}{preview}"
         )
 
     print(f"\n{c.BOLD}Sample:{c.NC}")
     sample_json = json.dumps(sample_for_display, indent=2, ensure_ascii=False)
-    print(f"  {sample_json[:SCHEMA_SAMPLE_TRUNCATE]}")
+    sample_text = sample_json[:SCHEMA_SAMPLE_TRUNCATE]
+    for line in sample_text.splitlines():
+        print(f"  {line}")
+    if len(sample_json) > SCHEMA_SAMPLE_TRUNCATE:
+        print("  ...")
 
-    first_paths = list(path_map)[:2]
-    if first_paths:
-        example = ", ".join(first_paths)
-        print(f'\n{c.DIM}Tip: jonq {json_file} "select {example}"{c.NC}')
+    suggestions = _suggest_queries(display_name, path_map)
+    if suggestions:
+        print(f"\n{c.BOLD}Suggested queries:{c.NC}")
+        for suggestion in suggestions:
+            print(f"  {c.DIM}{suggestion}{c.NC}")
 
 
 def _colorize_json(s: str) -> str:
@@ -1090,7 +1259,7 @@ def _show_schema_for_target(target: str) -> None:
     if target.startswith("http://") or target.startswith("https://"):
         tmp = _fetch_url(target)
         try:
-            _print_schema(tmp)
+            _print_schema(tmp, display_name=target)
         finally:
             os.remove(tmp)
         return

--- a/tests/jq_main_test.py
+++ b/tests/jq_main_test.py
@@ -143,18 +143,21 @@ def test_main_version(capsys):
     assert VERSION in captured.out
 
 
-def test_main_schema_preview_shows_nested_paths(tmp_path, capsys):
+def test_main_smart_inspect_shows_fields_and_suggestions(tmp_path, capsys):
     json_file = tmp_path / "nested.json"
     json_file.write_text(
-        '{"user":{"name":"Alice","address":{"city":"New York"}},"orders":[{"id":1,"price":1200}]}'
+        '[{"id":1,"name":"Alice","active":true,"user":{"address":{"city":"New York"}}}]'
     )
 
     with patch("sys.argv", ["jonq", str(json_file)]):
         main()
 
     captured = capsys.readouterr()
-    assert "Paths:" in captured.out
-    assert "user.name" in captured.out
+    assert "Root: array of objects" in captured.out
+    assert "Fields:" in captured.out
     assert "user.address.city" in captured.out
-    assert "orders[]" in captured.out
-    assert "orders[].price" in captured.out
+    assert "sample: \"Alice\"" in captured.out
+    assert "Suggested queries:" in captured.out
+    assert "select id, name, user.address.city" in captured.out
+    assert "select name" in captured.out
+    assert "where active = true" in captured.out

--- a/tests/test_main_edge_cases.py
+++ b/tests/test_main_edge_cases.py
@@ -6,6 +6,11 @@ from jonq.main import (
     _concat_glob,
     _type_label,
     _preview_value,
+    _collect_schema_paths,
+    _display_schema_type,
+    _format_schema_types,
+    _root_summary,
+    _suggest_queries,
     _json_to_raw,
     _json_to_yaml,
     _json_to_yaml_simple,
@@ -115,6 +120,37 @@ class TestPreviewValue:
     def test_simple_list(self):
         result = _preview_value([1, 2, 3])
         assert "1" in result
+
+
+class TestSmartInspectHelpers:
+    def test_display_schema_type_uses_readable_names(self):
+        assert _display_schema_type("str") == "string"
+        assert _display_schema_type("bool") == "boolean"
+        assert _display_schema_type("array[object{2}]") == "array[object]"
+
+    def test_format_schema_types_deduplicates_number_labels(self):
+        assert _format_schema_types(["int", "float", "str"]) == "number | string"
+
+    def test_root_summary_for_sampled_array(self):
+        summary = _root_summary("array", [{"id": 1}, {"id": 2}])
+
+        assert summary == "array of objects (sampled 2 items)"
+
+    def test_suggest_queries_from_schema_paths(self):
+        sample = [
+            {"id": 1, "name": "Alice", "active": True, "city": "Singapore"},
+            {"id": 2, "name": "Bob", "active": False, "city": "Tokyo"},
+        ]
+        paths = _collect_schema_paths(sample)
+
+        suggestions = _suggest_queries("users.json", paths)
+
+        assert 'jonq users.json "select id, name, city" -t' in suggestions
+        assert 'jonq users.json "select name" -r' in suggestions
+        assert (
+            'jonq users.json "select id, name, city where active = true" -t'
+            in suggestions
+        )
 
 
 class TestValidateInputFile:


### PR DESCRIPTION
## Summary
- Upgrade the no-query inspect path so jonq data.json shows root shape, readable field types, sample values, and suggested queries
- Generate copy-paste query suggestions from actual scalar, boolean, and groupable fields without adding new CLI flags
- Preserve URL display names in inspect suggestions instead of leaking temp paths
- Update README, usage docs, index docs, changelog, and tests

## Why
This moves jonq away from being just a jq syntax wrapper and toward helping users understand unknown JSON before they write a query.

## Verification
- pytest -q tests/jq_main_test.py tests/test_main_edge_cases.py
- pytest -q
- uvx ruff check --force-exclude jonq tests
- python -m compileall -q jonq
- LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-smart-inspect
- python -m pre_commit run --all-files
- python -m pre_commit run --hook-stage pre-push --all-files
- python -m jonq tests/json_test_files/simple.json