### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [v0.3.3] - 2026-04-30
 
 ### Added
 - **Query repair suggestions**: unknown fields in selected fields, filters, sorting, grouping, and aggregations now include nearby field matches plus a copy-paste `Try:` command.

--- a/jonq/constants.py
+++ b/jonq/constants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 USER_AGENT = f"jonq/{VERSION}"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jonq"
-version = "0.3.2"
+version = "0.3.3"
 description = "Readable jq for JSON extraction and exploration"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump package version from 0.3.2 to 0.3.3
- Move query repair changelog entry into the v0.3.3 release section

## Release notes
- Adds query repair suggestions for unknown fields in selected fields, filters, sorting, grouping, and aggregations
- Includes nearby field matches and a copy-paste Try command

## Verification
- pytest -q
- uvx ruff check --force-exclude jonq tests
- python -m compileall -q jonq
- python -m build
- python -m twine check dist/jonq-0.3.3*
- python -m jonq --version
- python -m jonq tests/json_test_files/simple.json "select name where cty = 'Chicago'"
- python -m pre_commit run --all-files
- python -m pre_commit run --hook-stage pre-push --all-files