### PR TITLE
Harden query repair edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Query repair suggestions** now handle dotted string literals, sparse arrays, nested leaf matches, quoted special-character keys, `from` queries, expression fields, and selected aliases in `having` clauses.
+
 ## [v0.3.3] - 2026-04-30
 
 ### Added

--- a/jonq/error_handler.py
+++ b/jonq/error_handler.py
@@ -43,6 +43,18 @@ def _fuzzy_suggest(
     return [c[1] for c in candidates[:FUZZY_MAX_RESULTS]]
 
 
+def _strip_quoted_strings(value: str) -> str:
+    return re.sub(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'', " ", value)
+
+
+def _format_query_field(path: str) -> str:
+    simple_segment = r"[A-Za-z_][\w]*(?:\[\])?"
+    if all(re.fullmatch(simple_segment, segment) for segment in path.split(".")):
+        return path
+    escaped = path.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def _collect_available_fields(data, prefix: str = "", depth: int = 0) -> list[str]:
     if depth > 5:
         return []
@@ -78,19 +90,31 @@ def _collect_available_fields(data, prefix: str = "", depth: int = 0) -> list[st
     return deduped
 
 
-def _best_field_suggestion(name: str, available: list[str]) -> str | None:
+def _best_field_suggestion(
+    name: str, available: list[str], aliases: list[str] | None = None
+) -> str | None:
+    aliases = aliases or []
+    alias_matches = _fuzzy_suggest(name, aliases)
+    if alias_matches:
+        return alias_matches[0]
+
+    name_leaf = name.replace("[]", "").split(".")[-1]
+    leaf_matches = []
+    for field in available:
+        field_leaf = field.replace("[]", "").split(".")[-1]
+        if name_leaf == field_leaf:
+            leaf_matches.append((0, _edit_distance(name, field), field))
+            continue
+        leaf_distance = _edit_distance(name_leaf.lower(), field_leaf.lower())
+        if leaf_distance <= 2:
+            leaf_matches.append((leaf_distance, _edit_distance(name, field), field))
+    leaf_matches.sort()
+    if leaf_matches:
+        return leaf_matches[0][2]
+
     direct = _fuzzy_suggest(name, available)
     if direct:
         return direct[0]
-
-    name_leaf = name.replace("[]", "").split(".")[-1]
-    leaf_matches = [
-        field
-        for field in available
-        if _fuzzy_suggest(name_leaf, [field.replace("[]", "").split(".")[-1]], max_dist=2)
-    ]
-    if leaf_matches:
-        return leaf_matches[0]
 
     return None
 
@@ -104,6 +128,44 @@ def _is_simple_field_ref(value: str | None) -> bool:
     if not value or value == "*":
         return False
     return bool(re.fullmatch(r"[A-Za-z_][\w]*(?:\[\])?(?:\.[A-Za-z_][\w]*(?:\[\])?)*", value))
+
+
+def _extract_from_data(data, from_path: str | None):
+    if not from_path:
+        return data
+
+    current = data
+    path = from_path.strip()
+    if path.startswith("[]"):
+        if not isinstance(current, list):
+            return None
+        current = current
+        path = path[2:].lstrip(".")
+    else:
+        current = [current]
+
+    if not path:
+        return current
+
+    for raw_segment in path.split("."):
+        if not raw_segment:
+            continue
+        expand = raw_segment.endswith("[]")
+        segment = raw_segment[:-2] if expand else raw_segment
+        next_items = []
+        for item in current:
+            if isinstance(item, dict) and segment in item:
+                value = item[segment]
+                if expand:
+                    if isinstance(value, list):
+                        next_items.extend(value)
+                else:
+                    if isinstance(value, list):
+                        next_items.extend(value)
+                    else:
+                        next_items.append(value)
+        current = next_items
+    return current
 
 
 def _field_refs_from_compiled(compiled) -> tuple[list[str], set[str]]:
@@ -133,6 +195,10 @@ def _field_refs_from_compiled(compiled) -> tuple[list[str], set[str]]:
             _, param, alias = field
             refs.append(param)
             aliases.add(alias)
+        elif kind == "expression":
+            _, expr, alias = field
+            refs.extend(_field_refs_from_expression(expr))
+            aliases.add(alias)
 
     refs.extend(getattr(compiled, "group_by", ()) or ())
 
@@ -154,6 +220,7 @@ def _field_refs_from_expression(expr: str | None) -> list[str]:
     if not expr:
         return []
 
+    expr = _strip_quoted_strings(expr)
     refs = []
     for match in re.finditer(r"\.([A-Za-z_][\w]*(?:\?\.[A-Za-z_][\w]*)*)\??", expr):
         refs.append(match.group(1).replace("?.", ".").rstrip("?"))
@@ -161,19 +228,47 @@ def _field_refs_from_expression(expr: str | None) -> list[str]:
     if refs:
         return refs
 
-    cleaned = re.sub(r"(['\"]).*?\1", " ", expr)
+    cleaned = expr
     skip = {
+        "abs",
         "and",
-        "or",
+        "avg",
+        "between",
+        "case",
+        "ceil",
+        "coalesce",
+        "contains",
+        "count",
+        "else",
+        "end",
+        "false",
+        "float",
+        "floor",
+        "fromdate",
+        "if_null",
+        "in",
+        "int",
+        "is",
+        "keys",
+        "length",
+        "like",
+        "lower",
+        "max",
+        "min",
         "not",
         "null",
+        "or",
+        "round",
+        "str",
+        "sum",
+        "then",
+        "todate",
+        "trim",
         "true",
-        "false",
-        "contains",
-        "in",
-        "like",
-        "between",
-        "is",
+        "type",
+        "upper",
+        "values",
+        "when",
     }
     for token in re.findall(r"\b[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*\b", cleaned):
         if token.lower() not in skip:
@@ -237,7 +332,7 @@ def _format_query_repair_message(
 ) -> str:
     repaired = query
     for old, new in replacements.items():
-        repaired = _replace_field_reference(repaired, old, new)
+        repaired = _replace_field_reference(repaired, old, _format_query_field(new))
 
     lines = [f"Unknown field(s): {', '.join(bad_refs)}"]
     nearby = []
@@ -440,19 +535,13 @@ def validate_query_against_schema(json_file: str, query) -> str | None:
         with open(json_file, "r", encoding="utf-8") as fp:
             data = json.load(fp)
 
-        if isinstance(data, list) and data:
-            sample = next((item for item in data if isinstance(item, dict)), data[0])
-        else:
-            sample = data
-
-        if not isinstance(sample, dict):
+        from_path = getattr(query, "from_path", None)
+        validation_data = _extract_from_data(data, from_path)
+        available = _collect_available_fields(validation_data)
+        if not available:
             return None
 
-        available = _collect_available_fields(sample)
         available_set = set(available)
-
-        if re.search(r"\bfrom\b", query_text, flags=re.IGNORECASE):
-            return None
 
         if hasattr(query, "fields"):
             refs, aliases = _field_refs_from_compiled(query)
@@ -471,7 +560,7 @@ def validate_query_against_schema(json_file: str, query) -> str | None:
             elif ref not in available_set:
                 bad.append(ref)
 
-            suggestion = _best_field_suggestion(ref, available)
+            suggestion = _best_field_suggestion(ref, available, sorted(aliases))
             if suggestion:
                 replacements[ref] = suggestion
 

--- a/jonq/main.py
+++ b/jonq/main.py
@@ -13,7 +13,7 @@ import shlex
 from collections import OrderedDict
 
 from jonq.api import compile_query, execute_async
-from jonq.error_handler import handle_error_with_context
+from jonq.error_handler import _format_query_field, handle_error_with_context
 from jonq.constants import (
     _Colors,
     VERSION,
@@ -361,7 +361,9 @@ def _format_suggested_command(source: str, query: str, *options: str) -> str:
 def _query_for_mixed_array(query: str, selected: list[str], mixed_array: bool) -> str:
     if not mixed_array or not selected:
         return query
-    return f"{query} where {selected[0]} is not null"
+    if _format_query_field(selected[0]) != selected[0]:
+        return query
+    return f"{query} where {_format_query_field(selected[0])} is not null"
 
 
 def _suggest_queries(source: str, path_map, *, mixed_array: bool = False) -> list[str]:
@@ -376,11 +378,12 @@ def _suggest_queries(source: str, path_map, *, mixed_array: bool = False) -> lis
     suggestions = []
     selected = _pick_select_fields(flat_scalars)
     if selected:
+        selected_query_fields = [_format_query_field(path) for path in selected]
         suggestions.append(
             _format_suggested_command(
                 source,
                 _query_for_mixed_array(
-                    f"select {', '.join(selected)}", selected, mixed_array
+                    f"select {', '.join(selected_query_fields)}", selected, mixed_array
                 ),
                 "-t",
             )
@@ -393,7 +396,9 @@ def _suggest_queries(source: str, path_map, *, mixed_array: bool = False) -> lis
     suggestions.append(
         _format_suggested_command(
             source,
-            _query_for_mixed_array(f"select {raw_field}", [raw_field], mixed_array),
+            _query_for_mixed_array(
+                f"select {_format_query_field(raw_field)}", [raw_field], mixed_array
+            ),
             "-r",
         )
     )
@@ -434,7 +439,7 @@ def _suggest_queries(source: str, path_map, *, mixed_array: bool = False) -> lis
             suggestions.append(
                 _format_suggested_command(
                     source,
-                    f"select {group_field}, count(*) as count group by {group_field}",
+                    f"select {_format_query_field(group_field)}, count(*) as count group by {_format_query_field(group_field)}",
                     "-t",
                 )
             )

--- a/tests/test_main_edge_cases.py
+++ b/tests/test_main_edge_cases.py
@@ -165,6 +165,24 @@ class TestSmartInspectHelpers:
     def test_sample_for_display_prefers_object_from_mixed_array(self):
         assert _sample_for_display([1, "two", {"key": "value"}]) == {"key": "value"}
 
+    def test_suggest_queries_quote_special_character_fields(self):
+        sample = {"first name": "Alice", "last-name": "Smith", "age_group": 3}
+        paths = _collect_schema_paths(sample)
+
+        suggestions = _suggest_queries("special.json", paths)
+
+        assert 'jonq special.json \'select "first name", "last-name", age_group\' -t' in suggestions
+        assert 'jonq special.json \'select "first name"\' -r' in suggestions
+
+    def test_mixed_array_suggestions_do_not_filter_quoted_fields(self):
+        sample = [1, {"first name": "Alice"}]
+        paths = _collect_schema_paths(sample)
+
+        suggestions = _suggest_queries("special.json", paths, mixed_array=True)
+
+        assert 'where "first name" is not null' not in "\n".join(suggestions)
+        assert 'jonq special.json \'select "first name"\' -t' in suggestions
+
 
 class TestValidateInputFile:
     def test_nonexistent_file(self):

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -4,7 +4,12 @@ import tempfile
 from jonq.query_parser import tokenize_query, parse_query
 from jonq.jq_filter import generate_jq_filter
 from jonq.api import compile_query
-from jonq.error_handler import _edit_distance, _fuzzy_suggest, validate_query_against_schema
+from jonq.error_handler import (
+    _edit_distance,
+    _format_query_field,
+    _fuzzy_suggest,
+    validate_query_against_schema,
+)
 from jonq.main import _looks_like_ndjson, _colorize_json, _type_label
 
 
@@ -208,6 +213,11 @@ class TestFuzzySuggestions:
         result = _fuzzy_suggest("a", ["ab", "ac", "ad", "ae", "af"])
         assert len(result) <= 3
 
+    def test_format_query_field_quotes_special_keys(self):
+        assert _format_query_field("name") == "name"
+        assert _format_query_field("first name") == '"first name"'
+        assert _format_query_field("profile.first name") == '"profile.first name"'
+
     def test_validate_schema_suggests_fields(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump([{"name": "Alice", "age": 30}], f)
@@ -264,6 +274,32 @@ class TestFuzzySuggestions:
         finally:
             os.unlink(tmp)
 
+    def test_validate_schema_repairs_having_alias_typo(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([{"city": "Chicago"}], f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(
+                tmp, compile_query("select city, count(*) as count group by city having cnt > 1")
+            )
+            assert result is not None
+            assert "cnt -> count" in result
+            assert '"select city, count(*) as count group by city having count > 1"' in result
+        finally:
+            os.unlink(tmp)
+
+    def test_validate_schema_allows_having_alias(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([{"city": "Chicago"}], f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(
+                tmp, compile_query("select city, count(*) as cnt group by city having cnt > 1")
+            )
+            assert result is None
+        finally:
+            os.unlink(tmp)
+
     def test_validate_schema_repairs_nested_field(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump([{"profile": {"email": "alice@example.com"}}], f)
@@ -275,6 +311,83 @@ class TestFuzzySuggestions:
             assert result is not None
             assert "profile.emali -> profile.email" in result
             assert '"select profile.email"' in result
+        finally:
+            os.unlink(tmp)
+
+    def test_validate_schema_ignores_dotted_string_literals(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([{"name": "Alice", "text": "Foo.Bar"}], f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(
+                tmp, compile_query("select name where text contains 'Foo.Bar'")
+            )
+            assert result is None
+        finally:
+            os.unlink(tmp)
+
+    def test_validate_schema_uses_sparse_array_fields(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([{"id": 1, "name": "Alice"}, {"id": 2, "age": 25}], f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(
+                tmp, compile_query("select id, name, age")
+            )
+            assert result is None
+        finally:
+            os.unlink(tmp)
+
+    def test_validate_schema_prefers_nested_leaf_match(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([{"profile": {"address": {"city": "New York"}}}], f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(
+                tmp, compile_query("select * where cty = 'New York'")
+            )
+            assert result is not None
+            assert "cty -> profile.address.city" in result
+        finally:
+            os.unlink(tmp)
+
+    def test_validate_schema_quotes_special_key_repairs(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"first name": "Alice", "age_group": 3}, f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(tmp, compile_query("select first_nme"))
+            assert result is not None
+            assert "first_nme -> first name" in result
+            assert "'select \"first name\"'" in result
+        finally:
+            os.unlink(tmp)
+
+    def test_validate_schema_repairs_from_query_fields(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([{"orders": [{"order_id": 1, "price": 20}]}], f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(
+                tmp, compile_query("select order_id, pric from [].orders")
+            )
+            assert result is not None
+            assert "pric -> price" in result
+            assert '"select order_id, price from [].orders"' in result
+        finally:
+            os.unlink(tmp)
+
+    def test_validate_schema_repairs_expression_fields(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([{"name": "Alice"}], f)
+            tmp = f.name
+        try:
+            result = validate_query_against_schema(
+                tmp, compile_query("select coalesce(nme, name) as display")
+            )
+            assert result is not None
+            assert "nme -> name" in result
+            assert '"select coalesce(name, name) as display"' in result
         finally:
             os.unlink(tmp)
 


### PR DESCRIPTION
## Summary
- Fix query repair false positives from dotted string literals like 'Foo.Bar'
- Validate against fields found across sparse arrays, not only the first object
- Prefer nested leaf matches and selected aliases when repairing typos
- Quote special-character keys in Smart Inspect suggestions and repair Try commands
- Validate fields inside from-query row contexts and selected expressions

## Deep sweep repros fixed
- python -m jonq tests/json_test_files/all.json "select name where text contains 'Foo.Bar'"
- python -m jonq tests/json_test_files/missing_fields.json "select id, name, age" -t
- python -m jonq tests/json_test_files/nested.json "select name where cty = 'New York'"
- python -m jonq tests/json_test_files/special_characters_keys.json
- python -m jonq tests/json_test_files/special_characters_keys.json "select first_nme"
- python -m jonq tests/json_test_files/nested.json "select order_id, pric from [].orders" -t
- python -m jonq tests/json_test_files/simple.json "select coalesce(nme, name) as display"
- python -m jonq tests/json_test_files/simple.json "select city, count(*) as count group by city having cnt > 1"

## Verification
- pytest -q tests/test_new_features.py tests/test_main_edge_cases.py
- pytest -q
- uvx ruff check --force-exclude jonq tests
- python -m compileall -q jonq
- LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-deep-sweep-final
- python -m pre_commit run --all-files
- python -m pre_commit run --hook-stage pre-push --all-files