### PR TITLE
Add JSON workbench commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **JSON workbench commands**: `jonq profile`, `jonq diff`, `jonq check`, and `jonq run`.
+- **`jonq.yaml` workflows** for named queries and repeatable field/type/null/count checks.
+- **Profile output** with field presence, null count, missing count, type conflicts, and sample values.
+- **Shape diffing** for added, removed, changed, newly optional, and newly nullable fields.
+
 ## [v0.3.4] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Use jonq when you need to:
 - select and rename fields without remembering jq object syntax
 - filter JSON with readable conditions
 - query nested objects and arrays
+- profile field presence, nulls, and type conflicts
+- diff JSON shape changes across files or runs
+- run repeatable local checks from `jonq.yaml`
 - produce table, CSV, JSONL, YAML, raw scalar, or compact JSON output
 - run the same query in shell scripts, CI, or Python code
 - follow NDJSON logs line-by-line
@@ -330,6 +333,72 @@ Suggested queries:
   jonq data.json "select city, count(*) as count group by city" -t
 ```
 
+## Profile, Diff, And Check
+
+Use `profile` when you need more than the quick no-query inspect view:
+
+```bash
+jonq profile response.json
+```
+
+It reports each discovered path, inferred types, present count, null count, missing count, and a sample value. Use JSON output when another tool needs the profile:
+
+```bash
+jonq profile response.json --format json
+```
+
+Compare two payload shapes with `diff`:
+
+```bash
+jonq diff old-response.json new-response.json
+jonq diff old-response.json new-response.json --fail-on-change
+```
+
+Run one-off checks from flags:
+
+```bash
+jonq check response.json \
+  --require id,email,status \
+  --type id:number \
+  --type email:string \
+  --no-null id,email \
+  --min-count 1
+```
+
+Or save queries and checks in `jonq.yaml`:
+
+```yaml
+queries:
+  active_users:
+    source: users.json
+    query: select id, email, status if status = 'active'
+    format: table
+
+checks:
+  user_contract:
+    source: users.json
+    require:
+      - id
+      - email
+      - status
+    types:
+      id: number
+      email: string
+      status: string
+    no_null:
+      - id
+      - email
+    min_count: 1
+```
+
+Then run the saved workflow:
+
+```bash
+jonq run active_users
+jonq check user_contract
+jonq check --all
+```
+
 ## Streaming and Watch Modes
 
 Streaming mode processes root-array JSON in chunks:
@@ -390,6 +459,17 @@ print(query([{"name": "Alice", "age": 30}], compiled))
 Async helpers are also available: `query_async(...)` and `execute_async(...)`.
 
 ## CLI Options
+
+Workbench commands:
+
+| Command | Description |
+|---------|-------------|
+| `jonq profile FILE` | Show field paths, types, present/null/missing counts, and samples |
+| `jonq diff OLD NEW` | Compare two JSON profiles and show shape drift |
+| `jonq check [NAME\|FILE]` | Run named checks from `jonq.yaml` or inline flag-based checks |
+| `jonq run NAME` | Run a named query from `jonq.yaml` |
+
+Query options:
 
 | Option | Description |
 |--------|-------------|

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,10 @@ Key Features
 - **JSONL / YAML output**: ``--format jsonl`` and ``--format yaml``
 - **Raw scalar output**: ``-r`` for unquoted values in shell pipelines
 - **Smart Inspect**: run ``jonq data.json`` to see fields, samples, and suggested queries
+- **Profile**: ``jonq profile data.json`` for field presence, nulls, missing counts, and type conflicts
+- **Diff**: ``jonq diff old.json new.json`` to catch shape drift
+- **Checks**: ``jonq check`` with inline assertions or named checks from ``jonq.yaml``
+- **Named queries**: ``jonq run NAME`` from ``jonq.yaml``
 - **Interactive REPL**: ``jonq -i data.json`` with tab completion and history
 - **Follow mode**: ``--follow`` to stream NDJSON line-by-line
 - **Streaming mode**: ``--stream`` for row-wise root-array queries

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,6 +14,10 @@ Run ``jonq`` with the following syntax:
 .. code-block:: bash
 
    jonq <path/to/json_file> "<query>" [options]
+   jonq profile <path/to/json_file>
+   jonq diff <old.json> <new.json>
+   jonq check [check_name|path/to/json_file]
+   jonq run <query_name>
 
 **Available Options:**
 
@@ -552,6 +556,76 @@ Run ``jonq`` with just a file (no query) to inspect the root shape, fields, samp
    jonq data.json
 
 This shows root type information, nested fields with inferred types, a truncated sample object, and copy-paste query suggestions based on the fields found in the data.
+
+Profile, Diff, And Check
+-------------------------
+
+Use ``profile`` when you need a fuller contract-oriented view of a payload:
+
+.. code-block:: bash
+
+   jonq profile response.json
+
+The profile shows each discovered path, inferred types, how many records contain
+that path, how many records contain ``null``, how many records are missing it,
+and a sample value. Use JSON output when another tool or CI job needs to consume
+the profile:
+
+.. code-block:: bash
+
+   jonq profile response.json --format json
+
+Compare two payload shapes with ``diff``:
+
+.. code-block:: bash
+
+   jonq diff old-response.json new-response.json
+   jonq diff old-response.json new-response.json --fail-on-change
+
+Run quick inline checks from flags:
+
+.. code-block:: bash
+
+   jonq check response.json \
+     --require id,email,status \
+     --type id:number \
+     --type email:string \
+     --no-null id,email \
+     --min-count 1
+
+For repeatable workflows, save named queries and checks in ``jonq.yaml``:
+
+.. code-block:: yaml
+
+   queries:
+     active_users:
+       source: users.json
+       query: select id, email, status if status = 'active'
+       format: table
+
+   checks:
+     user_contract:
+       source: users.json
+       require:
+         - id
+         - email
+         - status
+       types:
+         id: number
+         email: string
+         status: string
+       no_null:
+         - id
+         - email
+       min_count: 1
+
+Then run the saved workflow:
+
+.. code-block:: bash
+
+   jonq run active_users
+   jonq check user_contract
+   jonq check --all
 
 Interactive REPL
 -----------------

--- a/jonq/main.py
+++ b/jonq/main.py
@@ -14,6 +14,17 @@ from collections import OrderedDict
 
 from jonq.api import compile_query, execute_async
 from jonq.error_handler import _format_query_field, handle_error_with_context
+from jonq.workbench import (
+    build_profile,
+    build_profile_from_data,
+    compare_profiles,
+    format_check_result,
+    format_diff,
+    format_profile,
+    load_config,
+    normalize_list,
+    run_profile_check,
+)
 from jonq.constants import (
     _Colors,
     VERSION,
@@ -30,6 +41,8 @@ from jonq.constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+_WORKBENCH_COMMANDS = {"profile", "diff", "check", "run"}
 
 
 def _looks_like_ndjson(path: str) -> bool:
@@ -804,12 +817,13 @@ def _generate_completions(shell: str) -> str:
 _jonq_completions() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local opts="-i -f -t -r -s -n -o -p -w --format --table --raw --raw-output --stream --ndjson --limit --out --jq --explain --time --pretty --watch --follow --no-color --version --help --completions"
+    local commands="profile diff check run"
     local keywords="select if where from group by having sort asc desc limit distinct and or not in like between contains as case when then else end is null coalesce count sum avg min max upper lower length round abs ceil floor int float str type keys values trim todate fromdate date tojson fromjson"
 
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
     elif [[ "${COMP_CWORD}" == 1 ]]; then
-        COMPREPLY=($(compgen -f -X '!*.json' -- "${cur}") $(compgen -f -X '!*.jsonl' -- "${cur}"))
+        COMPREPLY=($(compgen -W "${commands}" -- "${cur}") $(compgen -f -X '!*.json' -- "${cur}") $(compgen -f -X '!*.jsonl' -- "${cur}"))
     else
         COMPREPLY=($(compgen -W "${keywords}" -- "${cur}"))
     fi
@@ -819,7 +833,7 @@ complete -F _jonq_completions jonq'''
         return '''# jonq zsh completion
 # Add to ~/.zshrc: eval "$(jonq --completions zsh)"
 _jonq() {
-    local -a opts keywords
+    local -a opts commands keywords
     opts=(
         '-i:Interactive mode'
         '-f:Output format'
@@ -839,11 +853,13 @@ _jonq() {
         '--no-color:No color'
         '--completions:Shell completions'
     )
+    commands=(profile diff check run)
     keywords=(select if where from group by having sort asc desc limit distinct and or not in like between contains as case when then else end is null coalesce count sum avg min max upper lower length round abs ceil floor int float str type keys values trim todate fromdate)
 
     if [[ "${words[2]}" == -* ]]; then
         _describe 'options' opts
     elif [[ ${CURRENT} -eq 2 ]]; then
+        compadd "${commands[@]}"
         _files -g '*.json(|l)'
     else
         compadd "${keywords[@]}"
@@ -869,6 +885,10 @@ complete -c jonq -l explain -d 'Explain query'
 complete -c jonq -l time -d 'Show timing'
 complete -c jonq -l no-color -d 'No color'
 complete -c jonq -l completions -d 'Shell completions' -x -a 'bash zsh fish'
+complete -c jonq -n '__fish_use_subcommand' -a 'profile' -d 'Profile JSON fields'
+complete -c jonq -n '__fish_use_subcommand' -a 'diff' -d 'Diff JSON profiles'
+complete -c jonq -n '__fish_use_subcommand' -a 'check' -d 'Run JSON checks'
+complete -c jonq -n '__fish_use_subcommand' -a 'run' -d 'Run named query'
 complete -c jonq -l version -d 'Show version\''''
     return ""
 
@@ -1019,8 +1039,13 @@ async def _amain(argv: list[str] | None = None):
         format="%(levelname)s:%(name)s:%(message)s", level=logging.WARNING
     )
 
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    if raw_argv and raw_argv[0] in _WORKBENCH_COMMANDS:
+        await _run_workbench_command(raw_argv)
+        return
+
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_argv)
 
     if getattr(args, "completions", None):
         print(_generate_completions(args.completions))
@@ -1155,6 +1180,10 @@ def _build_parser() -> argparse.ArgumentParser:
             '  jonq data.json "select name, age if age > 30"\n'
             '  jonq data.json "select name, age" -t\n'
             "  jonq data.json\n"
+            "  jonq profile data.json\n"
+            "  jonq diff old.json new.json\n"
+            "  jonq check user_contract\n"
+            "  jonq run active_users\n"
             "  jonq -i data.json\n"
             '  curl api.example.com/data | jonq "select id, name"\n'
             "  tail -f app.log | jonq --follow \"select level, msg if level = 'error'\"\n"
@@ -1287,6 +1316,300 @@ def _options_from_args(args: argparse.Namespace) -> dict:
         "no_color": args.no_color,
         "follow": getattr(args, "follow", False),
     }
+
+
+async def _run_workbench_command(argv: list[str]) -> None:
+    command = argv[0]
+    try:
+        if command == "profile":
+            _run_profile_command(argv[1:])
+        elif command == "diff":
+            _run_diff_command(argv[1:])
+        elif command == "check":
+            await _run_check_command(argv[1:])
+        elif command == "run":
+            await _run_named_query_command(argv[1:])
+        else:
+            raise ValueError(f"Unknown command: {command}")
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _run_profile_command(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        prog="jonq profile",
+        description="Profile JSON fields, types, nulls, and missing values.",
+    )
+    parser.add_argument("source", help="Local JSON or NDJSON file")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--max-records",
+        type=int,
+        help="Profile only the first N records",
+    )
+    args = parser.parse_args(argv)
+
+    validate_input_file(args.source)
+    profile = build_profile(args.source, max_records=args.max_records)
+    if args.format == "json":
+        print(json.dumps(profile.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        print(format_profile(profile))
+
+
+def _run_diff_command(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        prog="jonq diff",
+        description="Compare JSON profiles and show shape drift.",
+    )
+    parser.add_argument("old", help="Old/baseline JSON or NDJSON file")
+    parser.add_argument("new", help="New/current JSON or NDJSON file")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--fail-on-change",
+        action="store_true",
+        help="Exit with status 1 when profile changes are found",
+    )
+    args = parser.parse_args(argv)
+
+    validate_input_file(args.old)
+    validate_input_file(args.new)
+    diff = compare_profiles(build_profile(args.old), build_profile(args.new))
+    if args.format == "json":
+        print(json.dumps(diff.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        print(format_diff(diff))
+    if args.fail_on_change and diff.has_changes():
+        sys.exit(1)
+
+
+async def _run_check_command(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        prog="jonq check",
+        description="Run JSON contract checks from flags or jonq.yaml.",
+    )
+    parser.add_argument("target", nargs="?", help="Check name or source file")
+    parser.add_argument(
+        "-c",
+        "--config",
+        default="jonq.yaml",
+        help="Path to jonq.yaml",
+    )
+    parser.add_argument("--all", action="store_true", help="Run all configured checks")
+    parser.add_argument("--source", help="Source file for an inline check")
+    parser.add_argument(
+        "--require",
+        action="append",
+        help="Required field path; repeat or pass comma-separated values",
+    )
+    parser.add_argument(
+        "--no-null",
+        action="append",
+        help="Field path that must not contain null; repeat or comma-separate",
+    )
+    parser.add_argument(
+        "--type",
+        dest="types",
+        action="append",
+        help="Type expectation such as field:string or field=number|string",
+    )
+    parser.add_argument("--min-count", type=int, help="Minimum record count")
+    parser.add_argument("--max-count", type=int, help="Maximum record count")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format",
+    )
+    args = parser.parse_args(argv)
+
+    inline_requested = any(
+        (
+            args.source,
+            args.require,
+            args.no_null,
+            args.types,
+            args.min_count is not None,
+            args.max_count is not None,
+        )
+    )
+
+    specs: list[tuple[str, dict]] = []
+    if args.all or (not args.target and not inline_requested):
+        config = load_config(args.config)
+        checks = config.get("checks") or {}
+        if not isinstance(checks, dict) or not checks:
+            raise ValueError(f"No checks found in {args.config}.")
+        specs.extend((name, spec) for name, spec in checks.items())
+    elif inline_requested:
+        specs.append(("inline", _inline_check_spec(args)))
+    else:
+        config = load_config(args.config)
+        checks = config.get("checks") or {}
+        if not isinstance(checks, dict) or args.target not in checks:
+            raise ValueError(f"Check '{args.target}' was not found in {args.config}.")
+        specs.append((args.target, checks[args.target]))
+
+    results = []
+    for name, spec in specs:
+        if not isinstance(spec, dict):
+            raise ValueError(f"Check '{name}' must be a mapping.")
+        profile = await _profile_for_check_spec(name, spec)
+        results.append(run_profile_check(profile, spec, name))
+
+    if args.format == "json":
+        payload = [result.to_dict() for result in results]
+        if len(payload) == 1:
+            print(json.dumps(payload[0], ensure_ascii=False, indent=2))
+        else:
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print("\n\n".join(format_check_result(result) for result in results))
+
+    if any(not result.ok for result in results):
+        sys.exit(1)
+
+
+def _inline_check_spec(args: argparse.Namespace) -> dict:
+    source = args.source or args.target
+    if not source:
+        raise ValueError("Inline checks need a source file.")
+    spec: dict[str, object] = {"source": source}
+    if args.require:
+        spec["require"] = normalize_list(args.require)
+    if args.no_null:
+        spec["no_null"] = normalize_list(args.no_null)
+    if args.types:
+        spec["types"] = _parse_type_expectations(args.types)
+    if args.min_count is not None:
+        spec["min_count"] = args.min_count
+    if args.max_count is not None:
+        spec["max_count"] = args.max_count
+    if len(spec) == 1:
+        raise ValueError("Inline checks need at least one assertion.")
+    return spec
+
+
+def _parse_type_expectations(values: list[str]) -> dict[str, str]:
+    expectations = {}
+    for raw in values:
+        for item in normalize_list(raw):
+            if ":" in item:
+                path, expected = item.split(":", 1)
+            elif "=" in item:
+                path, expected = item.split("=", 1)
+            else:
+                raise ValueError(
+                    "--type expects field:type or field=type, for example id:number"
+                )
+            expectations[path.strip()] = expected.strip()
+    return expectations
+
+
+async def _profile_for_check_spec(name: str, spec: dict) -> object:
+    source = spec.get("source")
+    if not source:
+        raise ValueError(f"Check '{name}' needs a source.")
+    validate_input_file(source)
+
+    query = spec.get("query")
+    if query:
+        result = await execute_async(source, query, format="json", validate=True)
+        return build_profile_from_data(
+            result.data,
+            source=f"{source} | {query}",
+            root="query",
+        )
+
+    return build_profile(source)
+
+
+async def _run_named_query_command(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        prog="jonq run",
+        description="Run a named query from jonq.yaml.",
+    )
+    parser.add_argument("name", help="Named query from jonq.yaml")
+    parser.add_argument(
+        "-c",
+        "--config",
+        default="jonq.yaml",
+        help="Path to jonq.yaml",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=("json", "jsonl", "csv", "table", "yaml"),
+        help="Override configured output format",
+    )
+    parser.add_argument("-r", "--raw", "--raw-output", dest="raw_output", action="store_true")
+    parser.add_argument("-p", "--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument("-o", "--out", help="Write output to file")
+    parser.add_argument("--jq", dest="show_jq", action="store_true", help="Print jq")
+    parser.add_argument("--explain", action="store_true", help="Explain query")
+    parser.add_argument("--no-color", action="store_true", help="Disable color")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.config)
+    queries = config.get("queries") or {}
+    if not isinstance(queries, dict) or args.name not in queries:
+        raise ValueError(f"Query '{args.name}' was not found in {args.config}.")
+
+    spec = queries[args.name]
+    if not isinstance(spec, dict):
+        raise ValueError(f"Query '{args.name}' must be a mapping.")
+    source = spec.get("source")
+    query = spec.get("query")
+    if not source or not query:
+        raise ValueError(f"Query '{args.name}' needs source and query.")
+
+    fmt = args.format or spec.get("format") or "json"
+    options = {
+        "format": fmt,
+        "streaming": False,
+        "ndjson": False,
+        "limit": spec.get("limit"),
+        "out": args.out or spec.get("out"),
+        "show_jq": args.show_jq,
+        "explain": args.explain,
+        "show_time": False,
+        "pretty": args.pretty,
+        "raw_output": args.raw_output,
+        "watch": False,
+        "no_color": args.no_color,
+        "follow": False,
+    }
+    if options.get("raw_output") and options["format"] != "json":
+        raise ValueError("--raw/--raw-output can only be used with JSON output.")
+
+    validate_input_file(source)
+    result = await _run_query(source, query, options)
+    if result:
+        out_path = options.get("out")
+        if out_path:
+            import re
+
+            clean = re.sub(r"\033\[[0-9;]*m", "", result)
+            with open(out_path, "w", encoding="utf-8") as fp:
+                fp.write(clean + ("\n" if not clean.endswith("\n") else ""))
+        else:
+            print(result)
 
 
 def _show_schema_for_target(target: str) -> None:

--- a/jonq/workbench.py
+++ b/jonq/workbench.py
@@ -1,0 +1,684 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+import json
+import os
+import re
+
+
+MAX_SAMPLE_TEXT = 80
+
+
+@dataclass
+class FieldProfile:
+    path: str
+    present: int = 0
+    null: int = 0
+    types: OrderedDict[str, int] = field(default_factory=OrderedDict)
+    sample: Any = None
+    has_sample: bool = False
+
+    def add_record_values(self, values: list[Any]) -> None:
+        self.present += 1
+        if any(value is None for value in values):
+            self.null += 1
+
+        for value in values:
+            type_name = value_type(value)
+            self.types[type_name] = self.types.get(type_name, 0) + 1
+            if not self.has_sample and value is not None:
+                self.sample = value
+                self.has_sample = True
+
+        if not self.has_sample and values:
+            self.sample = values[0]
+            self.has_sample = True
+
+    def missing(self, total_records: int) -> int:
+        return max(0, total_records - self.present)
+
+    def non_null_types(self) -> set[str]:
+        return {type_name for type_name in self.types if type_name != "null"}
+
+    def to_dict(self, total_records: int) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "types": dict(self.types),
+            "present": self.present,
+            "null": self.null,
+            "missing": self.missing(total_records),
+            "sample": self.sample if self.has_sample else None,
+        }
+
+
+@dataclass
+class JsonProfile:
+    source: str
+    root: str
+    records: int
+    fields: OrderedDict[str, FieldProfile]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "root": self.root,
+            "records": self.records,
+            "fields": [
+                field.to_dict(self.records) for field in self.fields.values()
+            ],
+        }
+
+
+@dataclass
+class ProfileDiff:
+    old: JsonProfile
+    new: JsonProfile
+    added: list[str]
+    removed: list[str]
+    type_changed: list[tuple[str, set[str], set[str]]]
+    required_changed: list[tuple[str, int, int]]
+    nullability_changed: list[tuple[str, int, int]]
+
+    def has_changes(self) -> bool:
+        return bool(
+            self.added
+            or self.removed
+            or self.type_changed
+            or self.required_changed
+            or self.nullability_changed
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "old": self.old.source,
+            "new": self.new.source,
+            "added": self.added,
+            "removed": self.removed,
+            "type_changed": [
+                {
+                    "path": path,
+                    "old": sorted(old_types),
+                    "new": sorted(new_types),
+                }
+                for path, old_types, new_types in self.type_changed
+            ],
+            "required_changed": [
+                {"path": path, "old_missing": old_missing, "new_missing": new_missing}
+                for path, old_missing, new_missing in self.required_changed
+            ],
+            "nullability_changed": [
+                {"path": path, "old_null": old_null, "new_null": new_null}
+                for path, old_null, new_null in self.nullability_changed
+            ],
+            "changed": self.has_changes(),
+        }
+
+
+@dataclass
+class CheckResult:
+    name: str
+    source: str
+    ok: bool
+    records: int
+    failures: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "source": self.source,
+            "ok": self.ok,
+            "records": self.records,
+            "failures": self.failures,
+        }
+
+
+def load_json_source(path: str) -> tuple[Any, str]:
+    with open(path, "r", encoding="utf-8") as fp:
+        text = fp.read()
+
+    if not text.strip():
+        raise ValueError(f"JSON file '{path}' is empty.")
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        records = []
+        for line_no, raw_line in enumerate(text.splitlines(), start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSON on line {line_no} in '{path}': {exc.msg}"
+                ) from exc
+        if not records:
+            raise ValueError(f"JSON file '{path}' has no JSON records.")
+        return records, "ndjson"
+
+    if isinstance(data, list):
+        return data, "array"
+    if isinstance(data, dict):
+        return data, "object"
+    return data, "scalar"
+
+
+def build_profile(path: str, *, max_records: int | None = None) -> JsonProfile:
+    data, root = load_json_source(path)
+    return build_profile_from_data(data, source=path, root=root, max_records=max_records)
+
+
+def build_profile_from_data(
+    data: Any,
+    *,
+    source: str = "<memory>",
+    root: str | None = None,
+    max_records: int | None = None,
+) -> JsonProfile:
+    if root is None:
+        if isinstance(data, list):
+            root = "array"
+        elif isinstance(data, dict):
+            root = "object"
+        else:
+            root = "scalar"
+
+    records = data if isinstance(data, list) else [data]
+    if max_records is not None:
+        records = records[:max(0, max_records)]
+
+    fields: OrderedDict[str, FieldProfile] = OrderedDict()
+    for record in records:
+        record_paths: OrderedDict[str, list[Any]] = OrderedDict()
+        if isinstance(record, dict):
+            _collect_value_paths(record, "", record_paths)
+        elif isinstance(record, list):
+            _collect_value_paths(record, "value", record_paths)
+        else:
+            record_paths["value"] = [record]
+
+        for path, values in record_paths.items():
+            field_profile = fields.setdefault(path, FieldProfile(path=path))
+            field_profile.add_record_values(values)
+
+    return JsonProfile(source=source, root=root, records=len(records), fields=fields)
+
+
+def _collect_value_paths(
+    value: Any,
+    path: str,
+    paths: OrderedDict[str, list[Any]],
+) -> None:
+    if path:
+        paths.setdefault(path, []).append(value)
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            _collect_value_paths(child, child_path, paths)
+        return
+
+    if isinstance(value, list):
+        item_path = f"{path}[]" if path else "[]"
+        for child in value:
+            if isinstance(child, (dict, list)):
+                _collect_value_paths(child, item_path, paths)
+            else:
+                paths.setdefault(item_path, []).append(child)
+
+
+def value_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        if not value:
+            return "array[empty]"
+        labels = []
+        for item in value:
+            label = value_type(item)
+            if label not in labels:
+                labels.append(label)
+        return "array[" + " | ".join(labels) + "]"
+    return type(value).__name__
+
+
+def compare_profiles(old: JsonProfile, new: JsonProfile) -> ProfileDiff:
+    old_paths = set(old.fields)
+    new_paths = set(new.fields)
+    shared = sorted(old_paths & new_paths)
+
+    type_changed = []
+    required_changed = []
+    nullability_changed = []
+    for path in shared:
+        old_field = old.fields[path]
+        new_field = new.fields[path]
+
+        old_types = old_field.non_null_types()
+        new_types = new_field.non_null_types()
+        if old_types != new_types:
+            type_changed.append((path, old_types, new_types))
+
+        old_missing = old_field.missing(old.records)
+        new_missing = new_field.missing(new.records)
+        if (old_missing == 0) != (new_missing == 0):
+            required_changed.append((path, old_missing, new_missing))
+
+        if (old_field.null == 0) != (new_field.null == 0):
+            nullability_changed.append((path, old_field.null, new_field.null))
+
+    return ProfileDiff(
+        old=old,
+        new=new,
+        added=sorted(new_paths - old_paths),
+        removed=sorted(old_paths - new_paths),
+        type_changed=type_changed,
+        required_changed=required_changed,
+        nullability_changed=nullability_changed,
+    )
+
+
+def run_profile_check(profile: JsonProfile, spec: dict[str, Any], name: str) -> CheckResult:
+    failures = []
+
+    min_count = spec.get("min_count")
+    if min_count is not None and profile.records < int(min_count):
+        failures.append(
+            f"Expected at least {int(min_count)} record(s), found {profile.records}."
+        )
+
+    max_count = spec.get("max_count")
+    if max_count is not None and profile.records > int(max_count):
+        failures.append(
+            f"Expected at most {int(max_count)} record(s), found {profile.records}."
+        )
+
+    for path in normalize_list(spec.get("require")):
+        field_profile = profile.fields.get(path)
+        if field_profile is None:
+            failures.append(f"Required field '{path}' was not found.")
+            continue
+        missing = field_profile.missing(profile.records)
+        if missing:
+            failures.append(
+                f"Required field '{path}' is missing on {missing}/{profile.records} record(s)."
+            )
+
+    for path in normalize_list(spec.get("no_null")):
+        field_profile = profile.fields.get(path)
+        if field_profile is None:
+            failures.append(f"Field '{path}' was not found for no_null check.")
+            continue
+        if field_profile.null:
+            failures.append(
+                f"Field '{path}' is null on {field_profile.null}/{profile.records} record(s)."
+            )
+
+    types = spec.get("types") or {}
+    if not isinstance(types, dict):
+        raise ValueError("check 'types' must be a mapping of field path to type.")
+
+    for path, expected in types.items():
+        field_profile = profile.fields.get(path)
+        if field_profile is None:
+            failures.append(f"Field '{path}' was not found for type check.")
+            continue
+        expected_types = normalize_types(expected)
+        actual_types = field_profile.non_null_types()
+        if not actual_types and "null" in field_profile.types:
+            actual_types = {"null"}
+        unexpected = sorted(
+            type_name
+            for type_name in actual_types
+            if not type_is_allowed(type_name, expected_types)
+        )
+        if unexpected:
+            failures.append(
+                f"Field '{path}' expected type {format_type_set(expected_types)}, "
+                f"found {format_type_set(actual_types)}."
+            )
+
+    return CheckResult(
+        name=name,
+        source=profile.source,
+        ok=not failures,
+        records=profile.records,
+        failures=failures,
+    )
+
+
+def normalize_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple)):
+        items: list[str] = []
+        for item in value:
+            items.extend(normalize_list(item))
+        return items
+    return [str(value)]
+
+
+def normalize_types(value: Any) -> set[str]:
+    if isinstance(value, (list, tuple, set)):
+        raw = []
+        for item in value:
+            raw.extend(normalize_list(str(item).replace("|", ",")))
+    else:
+        raw = normalize_list(str(value).replace("|", ","))
+    aliases = {
+        "bool": "boolean",
+        "int": "number",
+        "float": "number",
+        "num": "number",
+        "str": "string",
+        "dict": "object",
+        "list": "array",
+    }
+    return {aliases.get(item.strip().lower(), item.strip().lower()) for item in raw}
+
+
+def type_is_allowed(actual: str, expected: set[str]) -> bool:
+    if actual in expected:
+        return True
+    if actual.startswith("array[") and "array" in expected:
+        return True
+    return False
+
+
+def format_type_set(types: set[str]) -> str:
+    if not types:
+        return "<none>"
+    return " | ".join(sorted(types))
+
+
+def format_profile(profile: JsonProfile) -> str:
+    lines = [
+        profile.source,
+        f"Root: {profile.root} ({profile.records} record{'s' if profile.records != 1 else ''})",
+    ]
+    if not profile.fields:
+        lines.append("No fields found.")
+        return "\n".join(lines)
+
+    rows = []
+    for field_profile in profile.fields.values():
+        rows.append(
+            {
+                "path": field_profile.path,
+                "types": " | ".join(field_profile.types.keys()),
+                "present": str(field_profile.present),
+                "null": str(field_profile.null),
+                "missing": str(field_profile.missing(profile.records)),
+                "sample": preview_value(field_profile.sample)
+                if field_profile.has_sample
+                else "",
+            }
+        )
+
+    lines.append("")
+    lines.append("Fields:")
+    lines.append(render_table(rows, ["path", "types", "present", "null", "missing", "sample"]))
+    return "\n".join(lines)
+
+
+def format_diff(diff: ProfileDiff) -> str:
+    lines = [
+        f"Schema diff: {diff.old.source} -> {diff.new.source}",
+    ]
+    if not diff.has_changes():
+        lines.append("No profile changes found.")
+        return "\n".join(lines)
+
+    if diff.added:
+        lines.append("")
+        lines.append("Added fields:")
+        for path in diff.added:
+            field_profile = diff.new.fields[path]
+            lines.append(f"  + {path} ({' | '.join(field_profile.types.keys())})")
+
+    if diff.removed:
+        lines.append("")
+        lines.append("Removed fields:")
+        for path in diff.removed:
+            field_profile = diff.old.fields[path]
+            lines.append(f"  - {path} ({' | '.join(field_profile.types.keys())})")
+
+    if diff.type_changed:
+        lines.append("")
+        lines.append("Type changes:")
+        for path, old_types, new_types in diff.type_changed:
+            lines.append(
+                f"  * {path}: {format_type_set(old_types)} -> {format_type_set(new_types)}"
+            )
+
+    if diff.required_changed:
+        lines.append("")
+        lines.append("Presence changes:")
+        for path, old_missing, new_missing in diff.required_changed:
+            lines.append(f"  * {path}: missing {old_missing} -> {new_missing}")
+
+    if diff.nullability_changed:
+        lines.append("")
+        lines.append("Nullability changes:")
+        for path, old_null, new_null in diff.nullability_changed:
+            lines.append(f"  * {path}: null {old_null} -> {new_null}")
+
+    return "\n".join(lines)
+
+
+def format_check_result(result: CheckResult) -> str:
+    status = "PASS" if result.ok else "FAIL"
+    lines = [
+        f"Check {result.name}: {status}",
+        f"Source: {result.source}",
+        f"Records: {result.records}",
+    ]
+    if result.failures:
+        lines.append("Failures:")
+        lines.extend(f"  - {failure}" for failure in result.failures)
+    return "\n".join(lines)
+
+
+def preview_value(value: Any) -> str:
+    text = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if len(text) > MAX_SAMPLE_TEXT:
+        return text[: MAX_SAMPLE_TEXT - 1] + "..."
+    return text
+
+
+def render_table(rows: list[dict[str, str]], headers: list[str]) -> str:
+    widths = {header: len(header) for header in headers}
+    for row in rows:
+        for header in headers:
+            widths[header] = max(widths[header], len(row.get(header, "")))
+
+    def line_for(row: dict[str, str]) -> str:
+        return "  ".join(row.get(header, "").ljust(widths[header]) for header in headers)
+
+    header_row = {header: header for header in headers}
+    separator = {header: "-" * widths[header] for header in headers}
+    return "\n".join([line_for(header_row), line_for(separator)] + [line_for(row) for row in rows])
+
+
+def load_config(path: str = "jonq.yaml") -> dict[str, Any]:
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Config file '{path}' was not found.")
+
+    with open(path, "r", encoding="utf-8") as fp:
+        text = fp.read()
+
+    data = parse_config_text(text)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Config file '{path}' must contain a mapping.")
+    return resolve_config_paths(data, path)
+
+
+def parse_config_text(text: str) -> Any:
+    stripped = text.strip()
+    if not stripped:
+        return {}
+
+    if stripped[0] in "[{":
+        return json.loads(stripped)
+
+    try:
+        import yaml
+
+        return yaml.safe_load(text)
+    except ImportError:
+        return parse_simple_yaml(text)
+
+
+def resolve_config_paths(config: dict[str, Any], config_path: str) -> dict[str, Any]:
+    resolved = deepcopy(config)
+    base_dir = Path(config_path).resolve().parent
+    for section in ("queries", "checks"):
+        entries = resolved.get(section)
+        if not isinstance(entries, dict):
+            continue
+        for spec in entries.values():
+            if not isinstance(spec, dict):
+                continue
+            source = spec.get("source")
+            if isinstance(source, str) and source != "-" and not os.path.isabs(source):
+                spec["source"] = str(base_dir / source)
+    return resolved
+
+
+def parse_simple_yaml(text: str) -> Any:
+    lines = []
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        lines.append((indent, raw_line.strip()))
+
+    if not lines:
+        return {}
+
+    value, index = _parse_yaml_block(lines, 0, lines[0][0])
+    if index != len(lines):
+        raise ValueError("Could not parse jonq.yaml.")
+    return value
+
+
+def _parse_yaml_block(
+    lines: list[tuple[int, str]],
+    index: int,
+    indent: int,
+) -> tuple[Any, int]:
+    container: dict[str, Any] | list[Any] | None = None
+
+    while index < len(lines):
+        current_indent, content = lines[index]
+        if current_indent < indent:
+            break
+        if current_indent > indent:
+            raise ValueError(f"Unexpected indentation near: {content}")
+
+        if content.startswith("- "):
+            if container is None:
+                container = []
+            if not isinstance(container, list):
+                raise ValueError("Cannot mix YAML lists and mappings at one level.")
+            item_text = content[2:].strip()
+            if item_text:
+                container.append(_parse_yaml_scalar(item_text))
+                index += 1
+            else:
+                child, index = _parse_yaml_child(lines, index, indent)
+                container.append(child)
+            continue
+
+        if container is None:
+            container = {}
+        if not isinstance(container, dict):
+            raise ValueError("Cannot mix YAML lists and mappings at one level.")
+
+        if ":" not in content:
+            raise ValueError(f"Expected key/value pair near: {content}")
+        key, raw_value = content.split(":", 1)
+        key = key.strip()
+        raw_value = raw_value.strip()
+        if raw_value:
+            container[key] = _parse_yaml_scalar(raw_value)
+            index += 1
+        else:
+            child, index = _parse_yaml_child(lines, index, indent)
+            container[key] = child
+
+    return container if container is not None else {}, index
+
+
+def _parse_yaml_child(
+    lines: list[tuple[int, str]],
+    index: int,
+    parent_indent: int,
+) -> tuple[Any, int]:
+    index += 1
+    if index >= len(lines) or lines[index][0] <= parent_indent:
+        return {}, index
+    return _parse_yaml_block(lines, index, lines[index][0])
+
+
+def _parse_yaml_scalar(value: str) -> Any:
+    value = value.strip()
+    if not value:
+        return ""
+    if (value[0], value[-1]) in {('"', '"'), ("'", "'")}:
+        return value[1:-1]
+    lowered = value.lower()
+    if lowered in ("true", "false"):
+        return lowered == "true"
+    if lowered in ("null", "none", "~"):
+        return None
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return [_parse_yaml_scalar(part) for part in _split_inline_list(inner)]
+    if re.fullmatch(r"-?\d+", value):
+        return int(value)
+    if re.fullmatch(r"-?\d+\.\d+", value):
+        return float(value)
+    return value
+
+
+def _split_inline_list(value: str) -> list[str]:
+    parts = []
+    current = []
+    quote = None
+    for char in value:
+        if quote:
+            current.append(char)
+            if char == quote:
+                quote = None
+            continue
+        if char in ("'", '"'):
+            quote = char
+            current.append(char)
+            continue
+        if char == ",":
+            parts.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    parts.append("".join(current).strip())
+    return parts

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -1,0 +1,180 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from jonq.main import main
+from jonq.workbench import (
+    build_profile,
+    compare_profiles,
+    parse_config_text,
+    run_profile_check,
+)
+
+
+def test_profile_tracks_missing_null_and_type_conflicts(tmp_path):
+    source = tmp_path / "users.json"
+    source.write_text(
+        json.dumps(
+            [
+                {"id": 1, "email": "a@example.com", "age": 30},
+                {"id": 2, "email": None},
+                {"id": 3, "age": "unknown"},
+            ]
+        )
+    )
+
+    profile = build_profile(str(source))
+
+    assert profile.records == 3
+    assert profile.fields["email"].present == 2
+    assert profile.fields["email"].null == 1
+    assert profile.fields["email"].missing(profile.records) == 1
+    assert set(profile.fields["age"].types) == {"number", "string"}
+
+
+def test_profile_diff_reports_added_removed_and_type_changes(tmp_path):
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(json.dumps([{"id": 1, "gone": True}]))
+    new.write_text(json.dumps([{"id": "1", "email": "a@example.com"}]))
+
+    diff = compare_profiles(build_profile(str(old)), build_profile(str(new)))
+
+    assert diff.has_changes()
+    assert diff.added == ["email"]
+    assert diff.removed == ["gone"]
+    assert diff.type_changed == [("id", {"number"}, {"string"})]
+
+
+def test_check_reports_contract_failures(tmp_path):
+    source = tmp_path / "users.json"
+    source.write_text(json.dumps([{"id": 1, "email": None}, {"id": 2}]))
+
+    profile = build_profile(str(source))
+    result = run_profile_check(
+        profile,
+        {
+            "require": ["id", "email"],
+            "types": {"id": "string"},
+            "no_null": ["email"],
+        },
+        "user_contract",
+    )
+
+    assert not result.ok
+    assert "Required field 'email' is missing" in "\n".join(result.failures)
+    assert "expected type string" in "\n".join(result.failures)
+    assert "is null" in "\n".join(result.failures)
+
+
+def test_parse_simple_jonq_yaml_config():
+    config = parse_config_text(
+        """
+queries:
+  users:
+    source: users.json
+    query: select id, email
+    format: table
+checks:
+  user_contract:
+    source: users.json
+    require:
+      - id
+      - email
+    types:
+      id: number
+      email: string
+    no_null: [id, email]
+    min_count: 1
+"""
+    )
+
+    assert config["queries"]["users"]["query"] == "select id, email"
+    assert config["checks"]["user_contract"]["require"] == ["id", "email"]
+    assert config["checks"]["user_contract"]["types"]["id"] == "number"
+    assert config["checks"]["user_contract"]["no_null"] == ["id", "email"]
+
+
+def test_cli_profile_command_outputs_profile(tmp_path, capsys):
+    source = tmp_path / "users.json"
+    source.write_text(json.dumps([{"id": 1, "email": "a@example.com"}]))
+
+    with patch("sys.argv", ["jonq", "profile", str(source)]):
+        main()
+
+    captured = capsys.readouterr()
+    assert "Root: array (1 record)" in captured.out
+    assert "email" in captured.out
+    assert "string" in captured.out
+
+
+def test_cli_named_check_uses_relative_config_paths(tmp_path, capsys):
+    source = tmp_path / "users.json"
+    config = tmp_path / "jonq.yaml"
+    source.write_text(json.dumps([{"id": 1, "email": "a@example.com"}]))
+    config.write_text(
+        """
+checks:
+  user_contract:
+    source: users.json
+    require:
+      - id
+      - email
+    types:
+      id: number
+      email: string
+    no_null:
+      - id
+      - email
+"""
+    )
+
+    with patch("sys.argv", ["jonq", "check", "user_contract", "--config", str(config)]):
+        main()
+
+    captured = capsys.readouterr()
+    assert "Check user_contract: PASS" in captured.out
+    assert str(source) in captured.out
+
+
+def test_cli_run_named_query_from_config(tmp_path, capsys):
+    source = tmp_path / "users.json"
+    config = tmp_path / "jonq.yaml"
+    source.write_text(
+        json.dumps(
+            [
+                {"id": 1, "email": "a@example.com"},
+                {"id": 2, "email": "b@example.com"},
+            ]
+        )
+    )
+    config.write_text(
+        """
+queries:
+  emails:
+    source: users.json
+    query: select email
+    format: json
+"""
+    )
+
+    with patch("sys.argv", ["jonq", "run", "emails", "--config", str(config), "-r"]):
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.out == "a@example.com\nb@example.com\n"
+
+
+def test_cli_inline_check_exits_nonzero_on_failure(tmp_path, capsys):
+    source = tmp_path / "users.json"
+    source.write_text(json.dumps([{"id": 1}]))
+
+    with patch("sys.argv", ["jonq", "check", str(source), "--require", "email"]):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Check inline: FAIL" in captured.out
+    assert "Required field 'email' was not found." in captured.out


### PR DESCRIPTION
## Summary
- Add profile, diff, check, and run commands to move jonq toward a repeatable JSON workbench workflow.
- Add jonq.yaml support for named queries and contract checks around required fields, types, nulls, and record counts.
- Document the new workflow in the README, Sphinx usage docs, index, and changelog.

## Direction
This keeps jonq focused on the first-mile JSON workflow: inspect/profile unfamiliar payloads, compare shape drift, and turn useful queries into repeatable local checks before expanding toward hosted or database-like features.

## Validation
- pytest -q
- python -m compileall -q jonq
- LC_ALL=C LANG=C python -m sphinx -b html docs/source /tmp/jonq-docs-json-workbench
- python -m pre_commit run --all-files
- python -m pre_commit run --hook-stage pre-push --all-files